### PR TITLE
Support fields "created" and "origin" for backup storages

### DIFF
--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -410,10 +410,7 @@ func TestCreateBackup(t *testing.T) {
 	// Create a backup
 	t.Logf("Creating backup of storage with UUID %s ...", storageDetails.UUID)
 
-	utc, err := time.LoadLocation("UTC")
-	handleError(err)
-
-	timeBeforeBackup := time.Now().In(utc)
+	timeBeforeBackup := utcTimeWithSecondPrecision()
 
 	backupDetails, err := svc.CreateBackup(&request.CreateBackupRequest{
 		UUID:  storageDetails.UUID,
@@ -423,7 +420,7 @@ func TestCreateBackup(t *testing.T) {
 	handleError(err)
 	waitForStorageOnline(storageDetails.UUID)
 
-	timeAfterBackup := time.Now().In(utc)
+	timeAfterBackup := utcTimeWithSecondPrecision()
 
 	t.Logf("Created backup with UUID %s", backupDetails.UUID)
 
@@ -771,6 +768,17 @@ func waitForStorageOnline(uuid string) {
 	})
 
 	handleError(err)
+}
+
+// Returns the current UTC time with second precision (milliseconds truncated).
+// This is the format we usually get from the UpCloud API.
+func utcTimeWithSecondPrecision() time.Time {
+	utc, err := time.LoadLocation("UTC")
+	handleError(err)
+
+	t := time.Now().In(utc).Truncate(time.Second)
+
+	return t
 }
 
 // Handles the error by panicing, thus stopping the test execution

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -409,6 +409,8 @@ func TestCreateBackup(t *testing.T) {
 
 	// Create a backup
 	t.Logf("Creating backup of storage with UUID %s ...", storageDetails.UUID)
+	timeBeforeBackup := time.Now()
+
 	backupDetails, err := svc.CreateBackup(&request.CreateBackupRequest{
 		UUID:  storageDetails.UUID,
 		Title: "Backup",
@@ -416,6 +418,7 @@ func TestCreateBackup(t *testing.T) {
 
 	handleError(err)
 	waitForStorageOnline(storageDetails.UUID)
+	timeAfterBackup := time.Now()
 	t.Logf("Created backup with UUID %s", backupDetails.UUID)
 
 	// Get backup storage details
@@ -428,6 +431,14 @@ func TestCreateBackup(t *testing.T) {
 
 	if backupStorageDetails.Origin != storageDetails.UUID {
 		t.Errorf("The origin UUID %s of backup storage UUID %s does not match the actual origina UUID %s", backupStorageDetails.Origin, backupDetails.UUID, storageDetails.UUID)
+	}
+
+	if backupStorageDetails.Created.Before(timeBeforeBackup) {
+		t.Errorf("The creation timestamp of backup storage UUID %s is too early", backupDetails.UUID)
+	}
+
+	if backupStorageDetails.Created.After(timeAfterBackup) {
+		t.Errorf("The creation timestamp of backup storage UUID %s is too late", backupDetails.UUID)
 	}
 
 	t.Logf("Backup storage origin UUID OK")

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -1,15 +1,16 @@
 package service
 
 import (
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 
 // The service object used by the tests
@@ -18,7 +19,7 @@ var svc *Service
 // TestMain is the main test method
 func TestMain(m *testing.M) {
 	setup()
-    retCode := m.Run()
+	retCode := m.Run()
 
 	// Optionally perform teardown
 	deleteResources := os.Getenv("UPCLOUD_GO_SDK_TEST_DELETE_RESOURCES")
@@ -393,6 +394,7 @@ func TestLoadEjectCDROM(t *testing.T) {
 //
 // - creates a storage device
 // - creates a backup of the storage device
+// - gets backup storage details
 //
 // It's not feasible to test backup restoration due to time constraints
 func TestCreateBackup(t *testing.T) {
@@ -415,6 +417,20 @@ func TestCreateBackup(t *testing.T) {
 	handleError(err)
 	waitForStorageOnline(storageDetails.UUID)
 	t.Logf("Created backup with UUID %s", backupDetails.UUID)
+
+	// Get backup storage details
+	t.Logf("Getting details of backup sorage with UUID %s ...", backupDetails.UUID)
+
+	backupStorageDetails, err := svc.GetStorageDetails(&request.GetStorageDetailsRequest{
+		UUID: backupDetails.UUID,
+	})
+	handleError(err)
+
+	if backupStorageDetails.Origin != storageDetails.UUID {
+		t.Errorf("The origin UUID %s of backup storage UUID %s does not match the actual origina UUID %s", backupStorageDetails.Origin, backupDetails.UUID, storageDetails.UUID)
+	}
+
+	t.Logf("Backup storage origin UUID OK")
 }
 
 // TestAttachModifyReleaseIPAddress performs the following actions

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -440,11 +440,11 @@ func TestCreateBackup(t *testing.T) {
 	}
 
 	if backupStorageDetails.Created.Before(timeBeforeBackup) {
-		t.Errorf("The creation timestamp of backup storage UUID %s is too early", backupDetails.UUID)
+		t.Errorf("The creation timestamp of backup storage UUID %s is too early: %v (should be after %v)", backupDetails.UUID, backupStorageDetails.Created, timeBeforeBackup)
 	}
 
 	if backupStorageDetails.Created.After(timeAfterBackup) {
-		t.Errorf("The creation timestamp of backup storage UUID %s is too late", backupDetails.UUID)
+		t.Errorf("The creation timestamp of backup storage UUID %s is too late: %v (should be before %v)", backupDetails.UUID, backupStorageDetails.Created, timeAfterBackup)
 	}
 
 	t.Logf("Backup storage origin UUID OK")

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -409,7 +409,11 @@ func TestCreateBackup(t *testing.T) {
 
 	// Create a backup
 	t.Logf("Creating backup of storage with UUID %s ...", storageDetails.UUID)
-	timeBeforeBackup := time.Now()
+
+	utc, err := time.LoadLocation("UTC")
+	handleError(err)
+
+	timeBeforeBackup := time.Now().In(utc)
 
 	backupDetails, err := svc.CreateBackup(&request.CreateBackupRequest{
 		UUID:  storageDetails.UUID,
@@ -418,7 +422,9 @@ func TestCreateBackup(t *testing.T) {
 
 	handleError(err)
 	waitForStorageOnline(storageDetails.UUID)
-	timeAfterBackup := time.Now()
+
+	timeAfterBackup := time.Now().In(utc)
+
 	t.Logf("Created backup with UUID %s", backupDetails.UUID)
 
 	// Get backup storage details

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -425,7 +425,7 @@ func TestCreateBackup(t *testing.T) {
 	t.Logf("Created backup with UUID %s", backupDetails.UUID)
 
 	// Get backup storage details
-	t.Logf("Getting details of backup sorage with UUID %s ...", backupDetails.UUID)
+	t.Logf("Getting details of backup storage with UUID %s ...", backupDetails.UUID)
 
 	backupStorageDetails, err := svc.GetStorageDetails(&request.GetStorageDetailsRequest{
 		UUID: backupDetails.UUID,

--- a/upcloud/storage.go
+++ b/upcloud/storage.go
@@ -1,6 +1,9 @@
 package upcloud
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"time"
+)
 
 // Constants
 const (
@@ -54,6 +57,9 @@ type Storage struct {
 	Type       string `xml:"type"`
 	UUID       string `xml:"uuid"`
 	Zone       string `xml:"zone"`
+	// Only for type "backup":
+	Origin  string    `xml:"origin"`
+	Created time.Time `xml:"created"`
 }
 
 // StorageDetails represents detailed information about a piece of storage


### PR DESCRIPTION
Should fix #45. Let me know if any changes are needed.