### PR TITLE
Extends account, adds account list and account details to api

### DIFF
--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -2,6 +2,66 @@ package upcloud
 
 // Account represents an account
 type Account struct {
-	Credits  float64 `xml:"credits"`
-	UserName string  `xml:"username"`
+	Credits        float64        `xml:"credits"`
+	UserName       string         `xml:"username"`
+	ResourceLimits resourceLimits `xml:"resource_limits"`
+}
+
+type resourceLimits struct {
+	Cores      int `xml:"cores"`
+	Memory     int `xml:"memory"`
+	Networks   int `xml:"networks"`
+	PublicIpv4 int `xml:"public_ipv4"`
+	PublicIpv6 int `xml:"public_ipv6"`
+	StorageHdd int `xml:"storage_hdd"`
+	StorageSsd int `xml:"storage_ssd"`
+}
+
+type AccountList struct {
+	Accounts []AccountListAccount `xml:"account"`
+}
+
+type AccountListAccount struct {
+	Roles    []string `xml:"roles>role"`
+	Type     string   `xml:"type"`
+	UserName string   `xml:"username"`
+}
+
+type AccountDetails struct {
+	FirstName              string   `xml:"first_name"`
+	LastName               string   `xml:"last_name"`
+	Phone                  string   `xml:"phone"`
+	Email                  string   `xml:"email"`
+	Company                string   `xml:"company"`
+	Address                string   `xml:"address"`
+	City                   string   `xml:"city"`
+	State                  string   `xml:"state"`
+	PostalCode             int      `xml:"postal_code"`
+	Country                string   `xml:"country"`
+	Timezone               string   `xml:"timezone"`
+	Currency               string   `xml:"currency"`
+	AllowApi               string   `xml:"allow_api"`
+	Enable3rdPartyServices string   `xml:"enable_3rd_party_services"`
+	Language               string   `xml:"language"`
+	Campaigns              []string `xml:"campaigns>campaign"`
+	Roles                  []string `xml:"roles>role"`
+	SimpleBackup           string   `xml:"simple_backup"`
+	Type                   string   `xml:"type"`
+	UserName               string   `xml:"username"`
+	VatNumber              string   `xml:"vat_number"`
+	NetworkAccess          []string `xml:"network_access>network"`
+	ServerAccess           []server `xml:"server_access>server"`
+	StorageAccess          []string `xml:"storage_access>storage"`
+	TagAccess              []tag    `xml:"tag_access>tag"`
+	IpFilter               []string `xml:"ip_filters>ip_filter"`
+}
+
+type server struct {
+	Storage string `xml:"storage"`
+	Uuid    string `xml:"uuid"`
+}
+
+type tag struct {
+	Name    string `xml:"name"`
+	Storage string `xml:"storage"`
 }

--- a/upcloud/account_test.go
+++ b/upcloud/account_test.go
@@ -10,8 +10,17 @@ import (
 func TestUnmarshalAccount(t *testing.T) {
 	originalXML := `<?xml version="1.0" encoding="utf-8"?>
 <account>
-    <credits>22465.536</credits>
-    <username>foobar</username>
+  <credits>22465.536</credits>
+  <resource_limits>
+    <cores>100</cores>
+    <memory>307200</memory>
+    <networks>100</networks>
+    <public_ipv4>20</public_ipv4>
+    <public_ipv6>100</public_ipv6>
+    <storage_hdd>10240</storage_hdd>
+    <storage_ssd>10240</storage_ssd>
+  </resource_limits>
+  <username>foobar</username>
 </account>`
 
 	account := Account{}
@@ -19,4 +28,90 @@ func TestUnmarshalAccount(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 22465.536, account.Credits)
 	assert.Equal(t, "foobar", account.UserName)
+	assert.Equal(t, 100, account.ResourceLimits.Cores)
+	assert.Equal(t, 307200, account.ResourceLimits.Memory)
+	assert.Equal(t, 100, account.ResourceLimits.Networks)
+	assert.Equal(t, 20, account.ResourceLimits.PublicIpv4)
+	assert.Equal(t, 100, account.ResourceLimits.PublicIpv6)
+	assert.Equal(t, 10240, account.ResourceLimits.StorageHdd)
+	assert.Equal(t, 10240, account.ResourceLimits.StorageSsd)
+}
+
+func TestUnmarshalAccountList(t *testing.T) {
+	originalXML := `<?xml version="1.0" encoding="utf-8"?>
+<accounts>
+  <account>
+    <roles>
+      <role>billing</role>
+      <role>technical</role>
+    </roles>
+    <type>main</type>
+    <username>foobar</username>
+  </account>
+</accounts>`
+
+	accountList := AccountList{}
+	err := xml.Unmarshal([]byte(originalXML), &accountList)
+	assert.Nil(t, err)
+	assert.Equal(t, "foobar", accountList.Accounts[0].UserName)
+	assert.Equal(t, "main", accountList.Accounts[0].Type)
+	assert.Equal(t, "billing", accountList.Accounts[0].Roles[0])
+	assert.Equal(t, "technical", accountList.Accounts[0].Roles[1])
+}
+
+func TestUnmarshalAccountDetails(t *testing.T) {
+	originalXML := `<?xml version="1.0" encoding="utf-8"?>
+<account>
+  <address>Address Name St</address>
+  <allow_api>yes</allow_api>
+  <campaigns>
+  </campaigns>
+  <city>Indianapolis</city>
+  <company>FooBar Inc.</company>
+  <country>USA</country>
+  <currency>USD</currency>
+  <email>user@email.com</email>
+  <enable_3rd_party_services>yes</enable_3rd_party_services>
+  <first_name>John</first_name>
+  <ip_filters>
+  </ip_filters>
+  <language>en</language>
+  <last_name>Doe</last_name>
+  <phone>+1.3173333333</phone>
+  <postal_code>46250</postal_code>
+  <roles>
+    <role>billing</role>
+    <role>technical</role>
+  </roles>
+  <simple_backup>no</simple_backup>
+  <state>Indiana</state>
+  <timezone>UTC</timezone>
+  <type>main</type>
+  <username>foobar</username>
+  <vat_number>FI24315605</vat_number>
+</account>`
+
+	accountDetails := AccountDetails{}
+	err := xml.Unmarshal([]byte(originalXML), &accountDetails)
+	assert.Nil(t, err)
+	assert.Equal(t, "John", accountDetails.FirstName)
+	assert.Equal(t, "Doe", accountDetails.LastName)
+	assert.Equal(t, "+1.3173333333", accountDetails.Phone)
+	assert.Equal(t, "user@email.com", accountDetails.Email)
+	assert.Equal(t, "FooBar Inc.", accountDetails.Company)
+	assert.Equal(t, "Address Name St", accountDetails.Address)
+	assert.Equal(t, "Indianapolis", accountDetails.City)
+	assert.Equal(t, "Indiana", accountDetails.State)
+	assert.Equal(t, 46250, accountDetails.PostalCode)
+	assert.Equal(t, "USA", accountDetails.Country)
+	assert.Equal(t, "UTC", accountDetails.Timezone)
+	assert.Equal(t, "USD", accountDetails.Currency)
+	assert.Equal(t, "yes", accountDetails.AllowApi)
+	assert.Equal(t, "yes", accountDetails.Enable3rdPartyServices)
+	assert.Equal(t, "en", accountDetails.Language)
+	assert.Equal(t, "billing", accountDetails.Roles[0])
+	assert.Equal(t, "no", accountDetails.SimpleBackup)
+	assert.Equal(t, "main", accountDetails.Type)
+	assert.Equal(t, "foobar", accountDetails.UserName)
+	assert.Equal(t, "FI24315605", accountDetails.VatNumber)
 }

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -37,6 +37,32 @@ func (s *Service) GetAccount() (*upcloud.Account, error) {
 	return &account, nil
 }
 
+func (s *Service) GetAccountList() (*upcloud.AccountList, error) {
+	accountList := upcloud.AccountList{}
+	response, err := s.basicGetRequest("/account/list")
+
+	if err != nil {
+		return nil, parseServiceError(err)
+	}
+
+	xml.Unmarshal(response, &accountList)
+
+	return &accountList, nil
+}
+
+func (s *Service) GetAccountDetails(account string) (*upcloud.AccountDetails, error) {
+	accountDetails := upcloud.AccountDetails{}
+	response, err := s.basicGetRequest(fmt.Sprintf("/account/details/%s", account))
+
+	if err != nil {
+		return nil, parseServiceError(err)
+	}
+
+	xml.Unmarshal(response, &accountDetails)
+
+	return &accountDetails, nil
+}
+
 // GetZones returns the available zones
 func (s *Service) GetZones() (*upcloud.Zones, error) {
 	zones := upcloud.Zones{}

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -106,6 +106,33 @@ func TestGetAccount(t *testing.T) {
 	}
 }
 
+func TestGetAccountList(t *testing.T) {
+	accountList, err := svc.GetAccountList()
+	username, _ := getCredentials()
+	handleError(err)
+	accountExists := false
+
+	for _, account := range accountList.Accounts {
+		if account.UserName == username {
+			accountExists = true
+		}
+	}
+
+	if accountExists != true {
+		t.Errorf("TestGetAccountList expected %t, got %t", true, false)
+	}
+}
+
+func TestGetAccountDetails(t *testing.T) {
+	username, _ := getCredentials()
+	accountDetails, err := svc.GetAccountDetails(username)
+	handleError(err)
+
+	if accountDetails.UserName != username {
+		t.Errorf("TestGetAccountDetails expected %s, got %s", username, accountDetails.UserName)
+	}
+}
+
 // TestErrorHandling checks that the correct error type is returned from service methods
 func TestErrorHandling(t *testing.T) {
 	// Perform a bogus request that will certainly fail


### PR DESCRIPTION
Hello UpCloud team,

I noticed a couple features were missing from the account api in the golang library. Below is a summary of the things I either extended or added. Let me know if there are any changes that need to be made before merging. 

- Extends account struct and service by adding Resource Limits which is a default response item from the '/account' api.
- Adds struct and service for '/account/list' api.
- Adds struct and service for '/account/detail/username' api.
- Adds and updates tests for new items and extensions.