### PR TITLE
client/service: better timeout handling

### DIFF
--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -42,7 +42,10 @@ func NewWithHTTPClient(userName string, password string, httpClient *http.Client
 	client.userName = userName
 	client.password = password
 	client.httpClient = httpClient
-	client.SetTimeout(time.Second * DefaultTimeout)
+	// Set the default timeout if the caller hasn't set its own
+	if client.httpClient.Timeout == 0 {
+		client.SetTimeout(time.Second * DefaultTimeout)
+	}
 
 	return &client
 }

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -222,12 +222,19 @@ func (s *Service) StartServer(r *request.StartServerRequest) (*upcloud.ServerDet
 
 // StopServer stops the specified server
 func (s *Service) StopServer(r *request.StopServerRequest) (*upcloud.ServerDetails, error) {
+	// Save previous timeout
+	prevTimeout := s.client.GetTimeout()
+
 	// Increase the client timeout to match the request timeout
-	s.client.SetTimeout(r.Timeout)
+	// Allow ten seconds to give the API a chance to respond with an error
+	s.client.SetTimeout(r.Timeout + 10*time.Second)
 
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := json.Marshal(r)
 	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	// Restore previous timeout
+	s.client.SetTimeout(prevTimeout)
 
 	if err != nil {
 		return nil, parseJSONServiceError(err)
@@ -240,12 +247,19 @@ func (s *Service) StopServer(r *request.StopServerRequest) (*upcloud.ServerDetai
 
 // RestartServer restarts the specified server
 func (s *Service) RestartServer(r *request.RestartServerRequest) (*upcloud.ServerDetails, error) {
+	// Save previous timeout
+	prevTimeout := s.client.GetTimeout()
+
 	// Increase the client timeout to match the request timeout
-	s.client.SetTimeout(r.Timeout)
+	// Allow ten seconds to give the API a chance to respond with an error
+	s.client.SetTimeout(r.Timeout + 10*time.Second)
 
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := json.Marshal(r)
 	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	// Restore previous timeout
+	s.client.SetTimeout(prevTimeout)
 
 	if err != nil {
 		return nil, parseJSONServiceError(err)


### PR DESCRIPTION
  * client: only set default timeout if the caller hasn't provieded a HTTP
            client with non-zero timeout.
  * service: restore timeout in server start and stop while allowing additional
             time for the API to respond with an error.