### PR TITLE
Storage import ioreader

### DIFF
--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -23,9 +23,10 @@ const (
 
 // Client represents an API client
 type Client struct {
-	userName   string
-	password   string
-	httpClient *http.Client
+	userName    string
+	password    string
+	httpClient  *http.Client
+	contentType string
 }
 
 // New creates ands returns a new client configured with the specified user and password
@@ -150,11 +151,22 @@ func (c *Client) PerformJSONPutUploadRequest(url string, requestBody io.Reader) 
 	return c.performJSONRequest(request)
 }
 
+func (c *Client) SetContentType(ct string) {
+	c.contentType = ct
+}
+
+func (c *Client) GetContentType() string {
+	if c.contentType == "" {
+		return "application/json"
+	}
+	return c.contentType
+}
+
 // Adds common headers to the specified request
 func (c *Client) addJSONRequestHeaders(request *http.Request) *http.Request {
 	request.SetBasicAuth(c.userName, c.password)
-	request.Header.Add("Accept", "application/json")
-	request.Header.Add("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", c.GetContentType())
 
 	return request
 }

--- a/upcloud/request/storage.go
+++ b/upcloud/request/storage.go
@@ -154,7 +154,7 @@ func (r DetachStorageRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
-//DeleteStorageRequest represents a request to delete a storage device
+// DeleteStorageRequest represents a request to delete a storage device
 type DeleteStorageRequest struct {
 	UUID string
 }
@@ -289,12 +289,18 @@ func (r *RestoreBackupRequest) RequestURL() string {
 	return fmt.Sprintf("/storage/%s/restore", r.UUID)
 }
 
+// ImportSourceLocation can be a string to a file or io.Reader in StorageImportSourceDirectUpload mode or a URL
+// in StorageImportSourceHTTPImport mode
+type ImportSourceLocation interface{}
+
 // CreateStorageImportRequest represent a request to import storage.
 type CreateStorageImportRequest struct {
 	StorageUUID string `json:"-"`
+	// ContentType can be given when using the StorageImportSourceDirectUpload mode
+	ContentType string `json:"-"`
 
-	Source         string `json:"source"`
-	SourceLocation string `json:"source_location,omitempty"`
+	Source         string               `json:"source"`
+	SourceLocation ImportSourceLocation `json:"source_location,omitempty"`
 }
 
 // MarshalJSON is a custom marshaller that deals with


### PR DESCRIPTION
  * request: SourceLocation is now untyped to allow passing of io.Reader
             instead of just string. This gives caller more flexibility
             while still providing ease of use. A new ContentType field
             allows the caller to specify if the locally available image
             is compressed or not.
  * service: support io.Reader by type asserting the SourceLocation.
             If it's string then it's used as a file name. Otherwise the
             io.Reader is passed as-is. Content type is set according
             to the request.
  * client:  support setting and getting of content type. Use the Set
             method instead of Add to reset the specified headers.