### PR TITLE
fix: omitempty on CreateServerStorageDevice

### DIFF
--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -58,7 +58,7 @@ type CreateServerStorageDevice struct {
 	Storage string `json:"storage"`
 	Title   string `json:"title,omitempty"`
 	// Storage size in gigabytes
-	Size int    `json:"size"`
+	Size int    `json:"size,omitempty"`
 	Tier string `json:"tier,omitempty"`
 	Type string `json:"type,omitempty"`
 }


### PR DESCRIPTION
size is optional (defaulting to the size of the original) when cloning a storage

terraform provider allows omitting size for storage when creating a new one with clone action (throwing an error, as not supported by the sdk).