### PR TITLE
fix: add omitempty for fields in account resourcelimits

### DIFF
--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -11,14 +11,14 @@ type Account struct {
 
 // ResourceLimits represents an account's resource limits
 type ResourceLimits struct {
-	Cores               int `json:"cores"`
-	DetachedFloatingIps int `json:"detached_floating_ips"`
-	Memory              int `json:"memory"`
-	Networks            int `json:"networks"`
-	PublicIPv4          int `json:"public_ipv4"`
-	PublicIPv6          int `json:"public_ipv6"`
-	StorageHDD          int `json:"storage_hdd"`
-	StorageSSD          int `json:"storage_ssd"`
+	Cores               int `json:"cores,omitempty"`
+	DetachedFloatingIps int `json:"detached_floating_ips,omitempty"`
+	Memory              int `json:"memory,omitempty"`
+	Networks            int `json:"networks,omitempty"`
+	PublicIPv4          int `json:"public_ipv4,omitempty"`
+	PublicIPv6          int `json:"public_ipv6,omitempty"`
+	StorageHDD          int `json:"storage_hdd,omitempty"`
+	StorageSSD          int `json:"storage_ssd,omitempty"`
 }
 
 // UnmarshalJSON is a custom unmarshaller that deals with

--- a/upcloud/account_test.go
+++ b/upcloud/account_test.go
@@ -42,3 +42,29 @@ func TestUnmarshalAccount(t *testing.T) {
 	assert.Equal(t, 10240, account.ResourceLimits.StorageHDD)
 	assert.Equal(t, 10240, account.ResourceLimits.StorageSSD)
 }
+
+// TestMarshalAccount tests that Account objects marshal correctly
+func TestMarshalAccount(t *testing.T) {
+	request := Account{
+		Credits:  100,
+		UserName: "username",
+		ResourceLimits: ResourceLimits{
+			Memory: 123,
+		},
+	}
+
+	expectedJSON := `
+	  {
+      "username": "username",
+      "credits": 100,
+      "resource_limits": {
+        "memory": 123
+      }
+	  }
+	`
+
+	actualJSON, err := json.Marshal(&request)
+	println(string(actualJSON))
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(actualJSON))
+}


### PR DESCRIPTION
unlimited resources were displayed as zero values (0) which was confusing