### PR TITLE
fix: backup_rule deletion

### DIFF
--- a/upcloud/storage.go
+++ b/upcloud/storage.go
@@ -159,10 +159,10 @@ func (s *StorageDetails) UnmarshalJSON(b []byte) error {
 
 // BackupRule represents a backup rule
 type BackupRule struct {
-	Interval string `json:"interval"`
+	Interval string `json:"interval,omitempty"`
 	// Time should be in the format "hhmm", e.g. "0430"
-	Time      string `json:"time"`
-	Retention int    `json:"retention,string"`
+	Time      string `json:"time,omitempty"`
+	Retention int    `json:"retention,string,omitempty"`
 }
 
 // ServerStorageDevice represents a storage device in the context of server requests or server details


### PR DESCRIPTION
the only way to delete the backup rule is to pass backup_rule: {} to the modify storage request. Currently this is not possible with the go api