### PR TITLE
Test: fix -short in tests

### DIFF
--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -319,9 +319,6 @@ func TestErrorHandling(t *testing.T) {
 // - stops the server
 // - deletes the server
 func TestCreateModifyDeleteServer(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "createmodifydeleteserver", func(t *testing.T, svc *Service) {
@@ -398,9 +395,6 @@ func TestCreateModifyDeleteServer(t *testing.T) {
 // - creates a server
 // - deletes the server including storage
 func TestCreateDeleteServerAndStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "createdeleteserverandstorage", func(t *testing.T, svc *Service) {
@@ -494,9 +488,6 @@ func TestGetIPAddresses(t *testing.T) {
 // - modifies the PTR record of the IP address
 // - deletes the IP address
 func TestAttachModifyReleaseIPAddress(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "attachmodifyreleaseipaddress", func(t *testing.T, svc *Service) {
@@ -671,9 +662,6 @@ func TestAttachModifyReleaseFloatingIPAddress(t *testing.T) {
 // - deletes the firewall rule
 //
 func TestFirewallRules(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "firewallrules", func(t *testing.T, svc *Service) {
@@ -848,9 +836,6 @@ func TestGetTags(t *testing.T) {
 //   - deletes the third tag
 //   - untags the first tag from the server
 func TestTagging(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "tagging", func(t *testing.T, svc *Service) {

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -31,11 +31,8 @@ func TestMain(m *testing.M) {
 
 // TestGetAccount tests that the GetAccount() method returns proper data
 func TestGetAccount(t *testing.T) {
-	if os.Getenv("UPCLOUD_GO_SDK_TEST_NO_CREDENTIALS") == "yes" {
+	if os.Getenv("UPCLOUD_GO_SDK_TEST_NO_CREDENTIALS") == "yes" || testing.Short() {
 		t.Skip("Skipping TestGetAccount...")
-	}
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
 	}
 
 	svc := getService()

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 
 // TestMain is the main test method
@@ -33,6 +34,9 @@ func TestMain(m *testing.M) {
 func TestGetAccount(t *testing.T) {
 	if os.Getenv("UPCLOUD_GO_SDK_TEST_NO_CREDENTIALS") == "yes" {
 		t.Skip("Skipping TestGetAccount...")
+	}
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
 	}
 
 	svc := getService()

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -8,11 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMain is the main test method

--- a/upcloud/service/storage_test.go
+++ b/upcloud/service/storage_test.go
@@ -22,9 +22,6 @@ import (
 // - modifies the storage
 // - deletes the storage
 func TestCreateModifyDeleteStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "createmodifydeletestorage", func(t *testing.T, svc *Service) {
@@ -63,9 +60,6 @@ func TestCreateModifyDeleteStorage(t *testing.T) {
 // - deletes the storage
 // - deletes the server
 func TestAttachDetachStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "attachdetachstorage", func(t *testing.T, svc *Service) {
@@ -115,9 +109,6 @@ func TestAttachDetachStorage(t *testing.T) {
 // - clones the storage device
 // - deletes the clone and the storage device
 func TestCloneStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "clonestorage", func(t *testing.T, svc *Service) {
@@ -149,9 +140,6 @@ func TestCloneStorage(t *testing.T) {
 // - deletes the new storage
 // - stops and deletes the server
 func TestTemplatizeServerStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "templatizeserverstorage", func(t *testing.T, svc *Service) {
@@ -196,9 +184,6 @@ func TestTemplatizeServerStorage(t *testing.T) {
 // - loads a CD-ROM
 // - ejects the CD-ROM
 func TestLoadEjectCDROM(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "loadejectcdrom", func(t *testing.T, svc *Service) {
@@ -249,9 +234,6 @@ func TestLoadEjectCDROM(t *testing.T) {
 // - restores the backup
 //
 func TestCreateRestoreBackup(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
 	t.Parallel()
 
 	record(t, "createrestorebackup", func(t *testing.T, svc *Service) {

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -30,7 +30,7 @@ func getService() *Service {
 // records the API interactions of the test
 func record(t *testing.T, fixture string, f func(*testing.T, *Service)) {
 	if testing.Short() {
-		t.Skip("Skipping test in short mode")
+		t.Skip("Skipping recorded test in short mode")
 	}
 
 	r, err := recorder.New("fixtures/" + fixture)

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 
 // Configures the test environment

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 
 // Configures the test environment
@@ -29,6 +30,10 @@ func getService() *Service {
 
 // records the API interactions of the test
 func record(t *testing.T, fixture string, f func(*testing.T, *Service)) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	r, err := recorder.New("fixtures/" + fixture)
 	require.NoError(t, err)
 


### PR DESCRIPTION
It seems like some tests that should be skipped with -short weren't, which is fixed with this PR.

This includes *all* tests using record(), as they all seem to require credentials to be set. (?)