### PR TITLE
Fix(network): implement router attach/detach

### DIFF
--- a/upcloud/request/network.go
+++ b/upcloud/request/network.go
@@ -60,7 +60,6 @@ type ModifyNetworkRequest struct {
 
 	Name       string                 `json:"name,omitempty"`
 	Zone       string                 `json:"zone,omitempty"`
-	Router     string                 `json:"router,omitempty"`
 	IPNetworks upcloud.IPNetworkSlice `json:"ip_networks,omitempty"`
 }
 

--- a/upcloud/request/network.go
+++ b/upcloud/request/network.go
@@ -90,6 +90,43 @@ func (r *DeleteNetworkRequest) RequestURL() string {
 	return fmt.Sprintf("/network/%s", r.UUID)
 }
 
+// AttachNetworkRouterRequest represents a request to attach a particular router to a network
+type AttachNetworkRouterRequest struct {
+	NetworkUUID string `json:"-"`
+	RouterUUID  string `json:"router"`
+}
+
+// RequestURL implements the Request interface
+func (r *AttachNetworkRouterRequest) RequestURL() string {
+	return (&ModifyNetworkRequest{UUID: r.NetworkUUID}).RequestURL()
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (r AttachNetworkRouterRequest) MarshalJSON() ([]byte, error) {
+	type localAttachNetworkRouterRequest AttachNetworkRouterRequest
+	v := struct {
+		AttachNetworkRouterRequest localAttachNetworkRouterRequest `json:"network"`
+	}{}
+	v.AttachNetworkRouterRequest = localAttachNetworkRouterRequest(r)
+
+	return json.Marshal(&v)
+}
+
+// DetachNetworkRouterRequest represents a request to detach a router from a network
+type DetachNetworkRouterRequest struct {
+	NetworkUUID string `json:"-"`
+}
+
+// RequestURL implements the Request interface
+func (r *DetachNetworkRouterRequest) RequestURL() string {
+	return (&ModifyNetworkRequest{UUID: r.NetworkUUID}).RequestURL()
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (r DetachNetworkRouterRequest) MarshalJSON() ([]byte, error) {
+	return []byte(`{ "network": { "router": null } }`), nil
+}
+
 // GetServerNetworksRequest represents a request to get the networks
 // a server is part of.
 type GetServerNetworksRequest struct {

--- a/upcloud/request/network_test.go
+++ b/upcloud/request/network_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 )
 
 // TestMarshalGetNetworksInZoneRequest tests that GetNetworksInZoneRequest behaves correctly
@@ -122,6 +123,47 @@ func TestMarshalDeleteNetwork(t *testing.T) {
 	}
 
 	assert.Equal(t, "/network/foo", request.RequestURL())
+}
+
+// TestMarshalAttachNetworkRouterRequest tests that AttachNetworkRouterRequest behaves correctly.
+func TestMarshalAttachNetworkRouterRequest(t *testing.T) {
+	request := AttachNetworkRouterRequest{
+		NetworkUUID: "mocknetworkuuid",
+		RouterUUID:  "mockrouteruuid",
+	}
+
+	expectedJSON := `
+	  {
+		"network": {
+		  "router": "mockrouteruuid"
+		}
+	  }
+	`
+
+	actualJSON, err := json.Marshal(&request)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(actualJSON))
+	assert.Equal(t, "/network/mocknetworkuuid", request.RequestURL())
+}
+
+// TestMarshalDetachNetworkRouterRequest tests that DetachNetworkRouterRequest behaves correctly.
+func TestMarshalDetachNetworkRouterRequest(t *testing.T) {
+	request := DetachNetworkRouterRequest{
+		NetworkUUID: "mocknetworkuuid",
+	}
+
+	expectedJSON := `
+	  {
+		"network": {
+		  "router": null
+		}
+	  }
+	`
+
+	actualJSON, err := json.Marshal(&request)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(actualJSON))
+	assert.Equal(t, "/network/mocknetworkuuid", request.RequestURL())
 }
 
 // TestMarshalGetServerNetworksRequest tests the GetServerNetworksRequest behaves correctly

--- a/upcloud/service/fixtures/createtwonetworkstwoserversandarouter.yaml
+++ b/upcloud/service/fixtures/createtwonetworkstwoserversandarouter.yaml
@@ -9,6 +9,8 @@ interactions:
       - application/json
       Content-Type:
       - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -32,7 +34,7 @@ interactions:
             },
             "name" : "test private network #1 (test)",
             "type" : "private",
-            "uuid" : "03c007f5-878c-4c1e-90c7-24cf6423c50e",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
             "zone" : "fi-hel2"
          }
       }
@@ -42,7 +44,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:51 GMT
+      - Fri, 21 May 2021 11:34:51 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -58,6 +60,8 @@ interactions:
       - application/json
       Content-Type:
       - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -81,7 +85,7 @@ interactions:
             },
             "name" : "test private network #2 (test)",
             "type" : "private",
-            "uuid" : "03d39bc9-f5a1-4336-9558-cad1c1a66f9f",
+            "uuid" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
             "zone" : "fi-hel2"
          }
       }
@@ -91,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:51 GMT
+      - Fri, 21 May 2021 11:34:51 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -107,6 +111,8 @@ interactions:
       - application/json
       Content-Type:
       - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
     url: https://api.upcloud.com/1.3/router
     method: POST
   response:
@@ -118,7 +124,7 @@ interactions:
             },
             "name" : "test router (test)",
             "type" : "normal",
-            "uuid" : "04ba2af3-d772-4f4b-9d30-52fe40f5a82e"
+            "uuid" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2"
          }
       }
     headers:
@@ -127,7 +133,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:51 GMT
+      - Fri, 21 May 2021 11:34:52 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -136,14 +142,16 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"network":{"router":"04ba2af3-d772-4f4b-9d30-52fe40f5a82e"}}'
+    body: '{"network":{"router":"04c83eec-7bdd-4b3a-a79d-b9118dc996d2"}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03c007f5-878c-4c1e-90c7-24cf6423c50e
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
     method: PUT
   response:
     body: |
@@ -165,9 +173,9 @@ interactions:
                ]
             },
             "name" : "test private network #1 (test)",
-            "router" : "04ba2af3-d772-4f4b-9d30-52fe40f5a82e",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
             "type" : "private",
-            "uuid" : "03c007f5-878c-4c1e-90c7-24cf6423c50e",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
             "zone" : "fi-hel2"
          }
       }
@@ -177,7 +185,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:52 GMT
+      - Fri, 21 May 2021 11:34:53 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -186,14 +194,68 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"network":{"router":"04ba2af3-d772-4f4b-9d30-52fe40f5a82e"}}'
+    body: ""
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03d39bc9-f5a1-4336-9558-cad1c1a66f9f
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
+    method: GET
+  response:
+    body: |
+      {
+         "network" : {
+            "ip_networks" : {
+               "ip_network" : [
+                  {
+                     "address" : "192.168.86.1/24",
+                     "dhcp" : "yes",
+                     "dhcp_default_route" : "no",
+                     "dhcp_dns" : [
+                        "192.168.86.10",
+                        "192.168.86.11"
+                     ],
+                     "family" : "IPv4",
+                     "gateway" : "192.168.86.1"
+                  }
+               ]
+            },
+            "name" : "test private network #1 (test)",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
+            "type" : "private",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "650"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:34:53 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"network":{"router":"04c83eec-7bdd-4b3a-a79d-b9118dc996d2"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/03455d35-69af-459b-b3c1-4bc2e40a3662
     method: PUT
   response:
     body: |
@@ -215,9 +277,9 @@ interactions:
                ]
             },
             "name" : "test private network #2 (test)",
-            "router" : "04ba2af3-d772-4f4b-9d30-52fe40f5a82e",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
             "type" : "private",
-            "uuid" : "03d39bc9-f5a1-4336-9558-cad1c1a66f9f",
+            "uuid" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
             "zone" : "fi-hel2"
          }
       }
@@ -227,7 +289,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:52 GMT
+      - Fri, 21 May 2021 11:34:53 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -236,13 +298,67 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testctntr1.example.com","metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000030060200","title":"disk1","size":30,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCTNTR1","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    body: ""
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/03455d35-69af-459b-b3c1-4bc2e40a3662
+    method: GET
+  response:
+    body: |
+      {
+         "network" : {
+            "ip_networks" : {
+               "ip_network" : [
+                  {
+                     "address" : "192.168.87.1/24",
+                     "dhcp" : "yes",
+                     "dhcp_default_route" : "no",
+                     "dhcp_dns" : [
+                        "192.168.87.10",
+                        "192.168.87.11"
+                     ],
+                     "family" : "IPv4",
+                     "gateway" : "192.168.87.1"
+                  }
+               ]
+            },
+            "name" : "test private network #2 (test)",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
+            "type" : "private",
+            "uuid" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "650"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:34:53 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testctntr1.example.com","metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000030080200","title":"disk1","size":30,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCTNTR1","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
     url: https://api.upcloud.com/1.3/server
     method: POST
   response:
@@ -251,24 +367,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -285,14 +401,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -302,14 +418,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -319,13 +435,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -334,13 +450,13 @@ interactions:
                }
             },
             "nic_model" : "virtio",
-            "password" : "9b6a3nde",
+            "password" : "546s9y8d",
             "plan" : "custom",
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "progress" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -349,8 +465,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -362,18 +479,18 @@ interactions:
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
             "username" : "root",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3793"
+      - "3830"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:52 GMT
+      - Fri, 21 May 2021 11:34:53 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -389,7 +506,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -397,24 +516,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -431,14 +550,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -448,14 +567,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -465,13 +584,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -485,7 +604,7 @@ interactions:
             "plan_ipv6_bytes" : "0",
             "progress" : "85",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -494,8 +613,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -506,18 +626,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3736"
+      - "3773"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:08:58 GMT
+      - Fri, 21 May 2021 11:35:01 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -533,7 +653,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -541,24 +663,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -575,14 +697,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -592,14 +714,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -609,13 +731,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -627,8 +749,9 @@ interactions:
             "plan" : "custom",
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
+            "progress" : "95",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -637,8 +760,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -649,18 +773,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3711"
+      - "3773"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:03 GMT
+      - Fri, 21 May 2021 11:35:06 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -676,7 +800,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -684,24 +810,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -718,14 +844,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -735,14 +861,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -752,13 +878,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -771,7 +897,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -780,8 +906,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -792,18 +919,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3711"
+      - "3748"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:08 GMT
+      - Fri, 21 May 2021 11:35:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -819,7 +946,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -827,25 +956,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
-            "host" : 7617135235,
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -862,14 +991,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -879,14 +1008,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -896,13 +1025,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -915,7 +1044,154 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
+            "remote_access_type" : "vnc",
+            "simple_backup" : "no",
+            "state" : "maintenance",
+            "storage_devices" : {
+               "storage_device" : [
+                  {
+                     "address" : "virtio:0",
+                     "boot_disk" : "0",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
+                     "storage_size" : 30,
+                     "storage_tier" : "maxiops",
+                     "storage_title" : "disk1",
+                     "type" : "disk"
+                  }
+               ]
+            },
+            "tags" : {
+               "tag" : []
+            },
+            "timezone" : "UTC",
+            "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
+            "video_model" : "cirrus",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "3775"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:35:16 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
+    method: GET
+  response:
+    body: |
+      {
+         "server" : {
+            "boot_order" : "disk",
+            "core_number" : "1",
+            "created" : 1621596893,
+            "firewall" : "off",
+            "host" : 6862160515,
+            "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
+            "ip_addresses" : {
+               "ip_address" : [
+                  {
+                     "access" : "utility",
+                     "address" : "10.6.4.94",
+                     "family" : "IPv4"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
+                     "family" : "IPv6"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "94.237.13.19",
+                     "family" : "IPv4"
+                  }
+               ]
+            },
+            "license" : 0,
+            "memory_amount" : "1024",
+            "metadata" : "no",
+            "networking" : {
+               "interfaces" : {
+                  "interface" : [
+                     {
+                        "bootable" : "no",
+                        "index" : 1,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "10.6.4.94",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
+                        "source_ip_filtering" : "yes",
+                        "type" : "utility"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 2,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "94.237.13.19",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 3,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
+                                 "family" : "IPv6",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:42:f3",
+                        "network" : "03000000-0000-4000-8046-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     }
+                  ]
+               }
+            },
+            "nic_model" : "virtio",
+            "plan" : "custom",
+            "plan_ipv4_bytes" : "0",
+            "plan_ipv6_bytes" : "0",
+            "remote_access_enabled" : "no",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "started",
@@ -924,8 +1200,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -936,18 +1213,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3734"
+      - "3771"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:14 GMT
+      - Fri, 21 May 2021 11:35:21 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -956,13 +1233,15 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testctntr2.example.com","metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000030060200","title":"disk1","size":30,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCTNTR2","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testctntr2.example.com","metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000030080200","title":"disk1","size":30,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCTNTR2","remote_access_enabled":"no","zone":"fi-hel2"}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
     url: https://api.upcloud.com/1.3/server
     method: POST
   response:
@@ -971,24 +1250,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -1005,14 +1284,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1022,13 +1301,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1039,13 +1318,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1054,13 +1333,13 @@ interactions:
                }
             },
             "nic_model" : "virtio",
-            "password" : "mrhg582b",
+            "password" : "89y6y346",
             "plan" : "custom",
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "progress" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -1069,8 +1348,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1082,18 +1362,18 @@ interactions:
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
             "username" : "root",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3793"
+      - "3834"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:14 GMT
+      - Fri, 21 May 2021 11:35:21 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1109,7 +1389,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -1117,24 +1399,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -1151,14 +1433,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1168,13 +1450,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1185,13 +1467,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1205,7 +1487,7 @@ interactions:
             "plan_ipv6_bytes" : "0",
             "progress" : "85",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -1214,8 +1496,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1226,18 +1509,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3736"
+      - "3777"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:20 GMT
+      - Fri, 21 May 2021 11:35:28 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1253,7 +1536,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -1261,24 +1546,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -1295,14 +1580,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1312,13 +1597,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1329,13 +1614,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1347,8 +1632,9 @@ interactions:
             "plan" : "custom",
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
+            "progress" : "95",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -1357,8 +1643,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1369,18 +1656,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3711"
+      - "3777"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:25 GMT
+      - Fri, 21 May 2021 11:35:33 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1396,7 +1683,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -1404,24 +1693,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -1438,14 +1727,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1455,13 +1744,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1472,13 +1761,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1491,7 +1780,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "maintenance",
@@ -1500,8 +1789,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1512,18 +1802,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3711"
+      - "3752"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:30 GMT
+      - Fri, 21 May 2021 11:35:38 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1539,7 +1829,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -1547,25 +1839,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
-            "host" : 7617135235,
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -1582,14 +1874,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1599,13 +1891,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1616,13 +1908,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1635,7 +1927,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "started",
@@ -1644,8 +1936,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1656,18 +1949,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3734"
+      - "3775"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:35 GMT
+      - Fri, 21 May 2021 11:35:43 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1683,7 +1976,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971/stop
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a/stop
     method: POST
   response:
     body: |
@@ -1691,25 +1986,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
-            "host" : 7617135235,
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -1726,14 +2021,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1743,14 +2038,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -1760,13 +2055,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1779,7 +2074,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "started",
@@ -1788,8 +2083,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1800,18 +2096,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3734"
+      - "3771"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:35 GMT
+      - Fri, 21 May 2021 11:35:44 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1827,7 +2123,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -1835,24 +2133,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -1869,14 +2168,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -1886,14 +2185,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -1903,13 +2202,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -1922,17 +2221,18 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
-            "state" : "stopped",
+            "state" : "maintenance",
             "storage_devices" : {
                "storage_device" : [
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -1943,18 +2243,164 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3707"
+      - "3775"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:41 GMT
+      - Fri, 21 May 2021 11:35:49 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
+    method: GET
+  response:
+    body: |
+      {
+         "server" : {
+            "boot_order" : "disk",
+            "core_number" : "1",
+            "created" : 1621596893,
+            "firewall" : "off",
+            "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
+            "ip_addresses" : {
+               "ip_address" : [
+                  {
+                     "access" : "utility",
+                     "address" : "10.6.4.94",
+                     "family" : "IPv4"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
+                     "family" : "IPv6"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "94.237.13.19",
+                     "family" : "IPv4"
+                  }
+               ]
+            },
+            "license" : 0,
+            "memory_amount" : "1024",
+            "metadata" : "no",
+            "networking" : {
+               "interfaces" : {
+                  "interface" : [
+                     {
+                        "bootable" : "no",
+                        "index" : 1,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "10.6.4.94",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
+                        "source_ip_filtering" : "yes",
+                        "type" : "utility"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 2,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "94.237.13.19",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 3,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
+                                 "family" : "IPv6",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:42:f3",
+                        "network" : "03000000-0000-4000-8046-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     }
+                  ]
+               }
+            },
+            "nic_model" : "virtio",
+            "plan" : "custom",
+            "plan_ipv4_bytes" : "0",
+            "plan_ipv6_bytes" : "0",
+            "remote_access_enabled" : "no",
+            "remote_access_password" : "MP9UZy83",
+            "remote_access_type" : "vnc",
+            "simple_backup" : "no",
+            "state" : "stopped",
+            "storage_devices" : {
+               "storage_device" : [
+                  {
+                     "address" : "virtio:0",
+                     "boot_disk" : "0",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
+                     "storage_size" : 30,
+                     "storage_tier" : "maxiops",
+                     "storage_title" : "disk1",
+                     "type" : "disk"
+                  }
+               ]
+            },
+            "tags" : {
+               "tag" : []
+            },
+            "timezone" : "UTC",
+            "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
+            "video_model" : "cirrus",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "3744"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:35:54 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1970,7 +2416,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2/stop
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17/stop
     method: POST
   response:
     body: |
@@ -1978,25 +2426,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
-            "host" : 7617135235,
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -2013,14 +2461,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -2030,13 +2478,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2047,13 +2495,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2066,7 +2514,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "started",
@@ -2075,8 +2523,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -2087,18 +2536,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3734"
+      - "3775"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:41 GMT
+      - Fri, 21 May 2021 11:35:54 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2114,7 +2563,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -2122,24 +2573,25 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
+            "host" : 6862160515,
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -2156,14 +2608,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -2173,13 +2625,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2190,13 +2642,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2209,17 +2661,18 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
-            "state" : "stopped",
+            "state" : "maintenance",
             "storage_devices" : {
                "storage_device" : [
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -2230,18 +2683,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "3707"
+      - "3779"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:46 GMT
+      - Fri, 21 May 2021 11:35:59 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2250,14 +2703,309 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"interface":{"type":"private","network":"03c007f5-878c-4c1e-90c7-24cf6423c50e","ip_addresses":{"ip_address":[{"family":"IPv4"}]}}}'
+    body: ""
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971/networking/interface
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
+    method: GET
+  response:
+    body: |
+      {
+         "server" : {
+            "boot_order" : "disk",
+            "core_number" : "1",
+            "created" : 1621596922,
+            "firewall" : "off",
+            "host" : 6862160515,
+            "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
+            "ip_addresses" : {
+               "ip_address" : [
+                  {
+                     "access" : "utility",
+                     "address" : "10.6.4.164",
+                     "family" : "IPv4"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
+                     "family" : "IPv6"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "94.237.106.32",
+                     "family" : "IPv4"
+                  }
+               ]
+            },
+            "license" : 0,
+            "memory_amount" : "1024",
+            "metadata" : "no",
+            "networking" : {
+               "interfaces" : {
+                  "interface" : [
+                     {
+                        "bootable" : "no",
+                        "index" : 1,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "10.6.4.164",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
+                        "source_ip_filtering" : "yes",
+                        "type" : "utility"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 2,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "94.237.106.32",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:33:a3",
+                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 3,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
+                                 "family" : "IPv6",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:3f:55",
+                        "network" : "03000000-0000-4000-8046-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     }
+                  ]
+               }
+            },
+            "nic_model" : "virtio",
+            "plan" : "custom",
+            "plan_ipv4_bytes" : "0",
+            "plan_ipv6_bytes" : "0",
+            "remote_access_enabled" : "no",
+            "remote_access_password" : "2eu9757T",
+            "remote_access_type" : "vnc",
+            "simple_backup" : "no",
+            "state" : "maintenance",
+            "storage_devices" : {
+               "storage_device" : [
+                  {
+                     "address" : "virtio:0",
+                     "boot_disk" : "0",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
+                     "storage_size" : 30,
+                     "storage_tier" : "maxiops",
+                     "storage_title" : "disk1",
+                     "type" : "disk"
+                  }
+               ]
+            },
+            "tags" : {
+               "tag" : []
+            },
+            "timezone" : "UTC",
+            "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
+            "video_model" : "cirrus",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "3779"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:36:04 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
+    method: GET
+  response:
+    body: |
+      {
+         "server" : {
+            "boot_order" : "disk",
+            "core_number" : "1",
+            "created" : 1621596922,
+            "firewall" : "off",
+            "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
+            "ip_addresses" : {
+               "ip_address" : [
+                  {
+                     "access" : "utility",
+                     "address" : "10.6.4.164",
+                     "family" : "IPv4"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
+                     "family" : "IPv6"
+                  },
+                  {
+                     "access" : "public",
+                     "address" : "94.237.106.32",
+                     "family" : "IPv4"
+                  }
+               ]
+            },
+            "license" : 0,
+            "memory_amount" : "1024",
+            "metadata" : "no",
+            "networking" : {
+               "interfaces" : {
+                  "interface" : [
+                     {
+                        "bootable" : "no",
+                        "index" : 1,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "10.6.4.164",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
+                        "source_ip_filtering" : "yes",
+                        "type" : "utility"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 2,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "94.237.106.32",
+                                 "family" : "IPv4",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:33:a3",
+                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     },
+                     {
+                        "bootable" : "no",
+                        "index" : 3,
+                        "ip_addresses" : {
+                           "ip_address" : [
+                              {
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
+                                 "family" : "IPv6",
+                                 "floating" : "no"
+                              }
+                           ]
+                        },
+                        "mac" : "b6:d7:db:b8:3f:55",
+                        "network" : "03000000-0000-4000-8046-000000000000",
+                        "source_ip_filtering" : "yes",
+                        "type" : "public"
+                     }
+                  ]
+               }
+            },
+            "nic_model" : "virtio",
+            "plan" : "custom",
+            "plan_ipv4_bytes" : "0",
+            "plan_ipv6_bytes" : "0",
+            "remote_access_enabled" : "no",
+            "remote_access_password" : "2eu9757T",
+            "remote_access_type" : "vnc",
+            "simple_backup" : "no",
+            "state" : "stopped",
+            "storage_devices" : {
+               "storage_device" : [
+                  {
+                     "address" : "virtio:0",
+                     "boot_disk" : "0",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
+                     "storage_size" : 30,
+                     "storage_tier" : "maxiops",
+                     "storage_title" : "disk1",
+                     "type" : "disk"
+                  }
+               ]
+            },
+            "tags" : {
+               "tag" : []
+            },
+            "timezone" : "UTC",
+            "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
+            "video_model" : "cirrus",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "3748"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:36:09 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"interface":{"type":"private","network":"0354393c-9867-48f2-b642-c60c5a3d5ba9","ip_addresses":{"ip_address":[{"family":"IPv4"}]}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a/networking/interface
     method: POST
   response:
     body: |
@@ -2274,8 +3022,8 @@ interactions:
                   }
                ]
             },
-            "mac" : "ee:1b:db:ca:ac:46",
-            "network" : "03c007f5-878c-4c1e-90c7-24cf6423c50e",
+            "mac" : "b6:d7:db:b8:e0:0c",
+            "network" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
             "source_ip_filtering" : "yes",
             "type" : "private"
          }
@@ -2286,7 +3034,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:46 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2295,14 +3043,16 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"interface":{"type":"private","network":"03d39bc9-f5a1-4336-9558-cad1c1a66f9f","ip_addresses":{"ip_address":[{"family":"IPv4"}]}}}'
+    body: '{"interface":{"type":"private","network":"03455d35-69af-459b-b3c1-4bc2e40a3662","ip_addresses":{"ip_address":[{"family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2/networking/interface
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17/networking/interface
     method: POST
   response:
     body: |
@@ -2319,8 +3069,8 @@ interactions:
                   }
                ]
             },
-            "mac" : "ee:1b:db:ca:dc:95",
-            "network" : "03d39bc9-f5a1-4336-9558-cad1c1a66f9f",
+            "mac" : "b6:d7:db:b8:a2:f3",
+            "network" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
             "source_ip_filtering" : "yes",
             "type" : "private"
          }
@@ -2331,7 +3081,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:46 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2347,7 +3097,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: GET
   response:
     body: |
@@ -2355,24 +3107,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846132,
+            "created" : 1621596893,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr1.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.239",
+                     "address" : "10.6.4.94",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.128",
+                     "address" : "94.237.13.19",
                      "family" : "IPv4"
                   }
                ]
@@ -2389,14 +3141,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.239",
+                                 "address" : "10.6.4.94",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:d6:31",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:ba:af",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -2406,14 +3158,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.128",
+                                 "address" : "94.237.13.19",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:8b",
-                        "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
+                        "mac" : "b6:d7:db:b8:3c:a6",
+                        "network" : "03000000-0000-4000-8095-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
                      },
@@ -2423,13 +3175,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:1d76",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:42f3",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:1d:76",
+                        "mac" : "b6:d7:db:b8:42:f3",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2446,8 +3198,8 @@ interactions:
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:ac:46",
-                        "network" : "03c007f5-878c-4c1e-90c7-24cf6423c50e",
+                        "mac" : "b6:d7:db:b8:e0:0c",
+                        "network" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
                         "source_ip_filtering" : "yes",
                         "type" : "private"
                      }
@@ -2459,7 +3211,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "MM93X7aU",
+            "remote_access_password" : "MP9UZy83",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "stopped",
@@ -2468,8 +3220,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0162cfeb-237f-43e4-8a29-d33a53be7117",
+                     "storage" : "0174270e-dd8a-4829-982d-3013ed8be1f4",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -2480,18 +3233,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-            "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971",
+            "uuid" : "0074c863-430e-4060-8aad-f0aad546473a",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "4330"
+      - "4367"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:47 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2507,7 +3260,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: GET
   response:
     body: |
@@ -2515,24 +3270,24 @@ interactions:
          "server" : {
             "boot_order" : "disk",
             "core_number" : "1",
-            "created" : 1597846154,
+            "created" : 1621596922,
             "firewall" : "off",
             "hostname" : "uploud-go-sdk-integration-test-testctntr2.example.com",
             "ip_addresses" : {
                "ip_address" : [
                   {
                      "access" : "utility",
-                     "address" : "10.6.6.240",
+                     "address" : "10.6.4.164",
                      "family" : "IPv4"
                   },
                   {
                      "access" : "public",
-                     "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                     "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                      "family" : "IPv6"
                   },
                   {
                      "access" : "public",
-                     "address" : "94.237.104.129",
+                     "address" : "94.237.106.32",
                      "family" : "IPv4"
                   }
                ]
@@ -2549,14 +3304,14 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "10.6.6.240",
+                                 "address" : "10.6.4.164",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:b2:9a",
-                        "network" : "03a002de-994e-45aa-9e1c-9918f0908c57",
+                        "mac" : "b6:d7:db:b8:f9:98",
+                        "network" : "03a6df69-e2b7-4ce8-b411-fbbbcef2bd58",
                         "source_ip_filtering" : "yes",
                         "type" : "utility"
                      },
@@ -2566,13 +3321,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "94.237.104.129",
+                                 "address" : "94.237.106.32",
                                  "family" : "IPv4",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:6b:e1",
+                        "mac" : "b6:d7:db:b8:33:a3",
                         "network" : "031457f4-0f8c-483c-96f2-eccede02909c",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2583,13 +3338,13 @@ interactions:
                         "ip_addresses" : {
                            "ip_address" : [
                               {
-                                 "address" : "2a04:3545:1000:720:ec1b:dbff:feca:172c",
+                                 "address" : "2a04:3545:1000:720:b4d7:dbff:feb8:3f55",
                                  "family" : "IPv6",
                                  "floating" : "no"
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:17:2c",
+                        "mac" : "b6:d7:db:b8:3f:55",
                         "network" : "03000000-0000-4000-8046-000000000000",
                         "source_ip_filtering" : "yes",
                         "type" : "public"
@@ -2606,8 +3361,8 @@ interactions:
                               }
                            ]
                         },
-                        "mac" : "ee:1b:db:ca:dc:95",
-                        "network" : "03d39bc9-f5a1-4336-9558-cad1c1a66f9f",
+                        "mac" : "b6:d7:db:b8:a2:f3",
+                        "network" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
                         "source_ip_filtering" : "yes",
                         "type" : "private"
                      }
@@ -2619,7 +3374,7 @@ interactions:
             "plan_ipv4_bytes" : "0",
             "plan_ipv6_bytes" : "0",
             "remote_access_enabled" : "no",
-            "remote_access_password" : "Qh79Mv8N",
+            "remote_access_password" : "2eu9757T",
             "remote_access_type" : "vnc",
             "simple_backup" : "no",
             "state" : "stopped",
@@ -2628,8 +3383,9 @@ interactions:
                   {
                      "address" : "virtio:0",
                      "boot_disk" : "0",
-                     "storage" : "0194abb1-c478-483c-8d52-cda69205f6df",
+                     "storage" : "016aa62f-a2bf-4f05-952b-c04a12827ad7",
                      "storage_size" : 30,
+                     "storage_tier" : "maxiops",
                      "storage_title" : "disk1",
                      "type" : "disk"
                   }
@@ -2640,18 +3396,18 @@ interactions:
             },
             "timezone" : "UTC",
             "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-            "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2",
+            "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17",
             "video_model" : "cirrus",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "4330"
+      - "4371"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:47 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2667,7 +3423,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03c007f5-878c-4c1e-90c7-24cf6423c50e
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
     method: GET
   response:
     body: |
@@ -2689,17 +3447,17 @@ interactions:
                ]
             },
             "name" : "test private network #1 (test)",
-            "router" : "04ba2af3-d772-4f4b-9d30-52fe40f5a82e",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
             "servers" : {
                "server" : [
                   {
                      "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
-                     "uuid" : "00c88e0e-f7f7-4835-8000-a68645ada971"
+                     "uuid" : "0074c863-430e-4060-8aad-f0aad546473a"
                   }
                ]
             },
             "type" : "private",
-            "uuid" : "03c007f5-878c-4c1e-90c7-24cf6423c50e",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
             "zone" : "fi-hel2"
          }
       }
@@ -2709,7 +3467,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:47 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2725,7 +3483,9 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03d39bc9-f5a1-4336-9558-cad1c1a66f9f
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/03455d35-69af-459b-b3c1-4bc2e40a3662
     method: GET
   response:
     body: |
@@ -2747,17 +3507,17 @@ interactions:
                ]
             },
             "name" : "test private network #2 (test)",
-            "router" : "04ba2af3-d772-4f4b-9d30-52fe40f5a82e",
+            "router" : "04c83eec-7bdd-4b3a-a79d-b9118dc996d2",
             "servers" : {
                "server" : [
                   {
                      "title" : "uploud-go-sdk-integration-test-TestCTNTR2",
-                     "uuid" : "00cb2451-9d47-4650-b393-3e2bb213f9b2"
+                     "uuid" : "0070dc51-99e2-477a-b77a-d44e251b7a17"
                   }
                ]
             },
             "type" : "private",
-            "uuid" : "03d39bc9-f5a1-4336-9558-cad1c1a66f9f",
+            "uuid" : "03455d35-69af-459b-b3c1-4bc2e40a3662",
             "zone" : "fi-hel2"
          }
       }
@@ -2767,7 +3527,58 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 19 Aug 2020 14:09:47 GMT
+      - Fri, 21 May 2021 11:36:09 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"network":{"router":null}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
+    method: PUT
+  response:
+    body: |
+      {
+         "network" : {
+            "ip_networks" : {
+               "ip_network" : [
+                  {
+                     "address" : "192.168.86.1/24",
+                     "dhcp" : "yes",
+                     "dhcp_default_route" : "no",
+                     "dhcp_dns" : [
+                        "192.168.86.10",
+                        "192.168.86.11"
+                     ],
+                     "family" : "IPv4",
+                     "gateway" : "192.168.86.1"
+                  }
+               ]
+            },
+            "name" : "test private network #1 (test)",
+            "type" : "private",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "593"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:36:09 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2783,13 +3594,74 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00c88e0e-f7f7-4835-8000-a68645ada971
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
+    method: GET
+  response:
+    body: |
+      {
+         "network" : {
+            "ip_networks" : {
+               "ip_network" : [
+                  {
+                     "address" : "192.168.86.1/24",
+                     "dhcp" : "yes",
+                     "dhcp_default_route" : "no",
+                     "dhcp_dns" : [
+                        "192.168.86.10",
+                        "192.168.86.11"
+                     ],
+                     "family" : "IPv4",
+                     "gateway" : "192.168.86.1"
+                  }
+               ]
+            },
+            "name" : "test private network #1 (test)",
+            "servers" : {
+               "server" : [
+                  {
+                     "title" : "uploud-go-sdk-integration-test-TestCTNTR1",
+                     "uuid" : "0074c863-430e-4060-8aad-f0aad546473a"
+                  }
+               ]
+            },
+            "type" : "private",
+            "uuid" : "0354393c-9867-48f2-b642-c60c5a3d5ba9",
+            "zone" : "fi-hel2"
+         }
+      }
+    headers:
+      Content-Length:
+      - "816"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 21 May 2021 11:36:11 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0074c863-430e-4060-8aad-f0aad546473a
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Wed, 19 Aug 2020 14:09:47 GMT
+      - Fri, 21 May 2021 11:36:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2805,13 +3677,15 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/server/00cb2451-9d47-4650-b393-3e2bb213f9b2
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/server/0070dc51-99e2-477a-b77a-d44e251b7a17
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Wed, 19 Aug 2020 14:09:48 GMT
+      - Fri, 21 May 2021 11:36:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2827,13 +3701,15 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03c007f5-878c-4c1e-90c7-24cf6423c50e
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/0354393c-9867-48f2-b642-c60c5a3d5ba9
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Wed, 19 Aug 2020 14:09:48 GMT
+      - Fri, 21 May 2021 11:36:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2849,13 +3725,15 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/network/03d39bc9-f5a1-4336-9558-cad1c1a66f9f
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/network/03455d35-69af-459b-b3c1-4bc2e40a3662
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Wed, 19 Aug 2020 14:09:49 GMT
+      - Fri, 21 May 2021 11:36:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -2871,13 +3749,15 @@ interactions:
       - application/json
       Content-Type:
       - application/json
-    url: https://api.upcloud.com/1.3/router/04ba2af3-d772-4f4b-9d30-52fe40f5a82e
+      User-Agent:
+      - upcloud-go-api/3.0.0
+    url: https://api.upcloud.com/1.3/router/04c83eec-7bdd-4b3a-a79d-b9118dc996d2
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Wed, 19 Aug 2020 14:09:49 GMT
+      - Fri, 21 May 2021 11:36:11 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/network.go
+++ b/upcloud/service/network.go
@@ -15,6 +15,8 @@ type Network interface {
 	GetNetworkDetails(r *request.GetNetworkDetailsRequest) (*upcloud.Network, error)
 	ModifyNetwork(r *request.ModifyNetworkRequest) (*upcloud.Network, error)
 	DeleteNetwork(r *request.DeleteNetworkRequest) error
+	AttachNetworkRouter(r *request.AttachNetworkRouterRequest) error
+	DetachNetworkRouter(r *request.DetachNetworkRouterRequest) error
 	GetServerNetworks(r *request.GetServerNetworksRequest) (*upcloud.Networking, error)
 	CreateNetworkInterface(r *request.CreateNetworkInterfaceRequest) (*upcloud.Interface, error)
 	ModifyNetworkInterface(r *request.ModifyNetworkInterfaceRequest) (*upcloud.Interface, error)
@@ -123,6 +125,28 @@ func (s *Service) DeleteNetwork(r *request.DeleteNetworkRequest) error {
 		return parseJSONServiceError(err)
 	}
 
+	return nil
+}
+
+// AttachNetworkRouter attaches a router to the specified network.
+func (s *Service) AttachNetworkRouter(r *request.AttachNetworkRouterRequest) error {
+	requestBody, _ := json.Marshal(r)
+	_, err := s.client.PerformJSONPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	if err != nil {
+		return parseJSONServiceError(err)
+	}
+	return nil
+}
+
+// DetachNetworkRouter detaches a router from the specified network.
+func (s *Service) DetachNetworkRouter(r *request.DetachNetworkRouterRequest) error {
+	requestBody, _ := json.Marshal(r)
+	_, err := s.client.PerformJSONPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	if err != nil {
+		return parseJSONServiceError(err)
+	}
 	return nil
 }
 

--- a/upcloud/service/network_test.go
+++ b/upcloud/service/network_test.go
@@ -334,17 +334,21 @@ func TestCreateTwoNetworksTwoServersAndARouter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		network1, err = svc.ModifyNetwork(&request.ModifyNetworkRequest{
-			Router: router.UUID,
-			UUID:   network1.UUID,
+		err = svc.AttachNetworkRouter(&request.AttachNetworkRouterRequest{
+			RouterUUID:  router.UUID,
+			NetworkUUID: network1.UUID,
 		})
+		require.NoError(t, err)
+		network1, err = svc.GetNetworkDetails(&request.GetNetworkDetailsRequest{UUID: network1.UUID})
 		require.NoError(t, err)
 		require.Equal(t, network1.Router, router.UUID)
 
-		network2, err = svc.ModifyNetwork(&request.ModifyNetworkRequest{
-			Router: router.UUID,
-			UUID:   network2.UUID,
+		err = svc.AttachNetworkRouter(&request.AttachNetworkRouterRequest{
+			RouterUUID:  router.UUID,
+			NetworkUUID: network2.UUID,
 		})
+		require.NoError(t, err)
+		network2, err = svc.GetNetworkDetails(&request.GetNetworkDetailsRequest{UUID: network2.UUID})
 		require.NoError(t, err)
 		require.Equal(t, network2.Router, router.UUID)
 

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -172,7 +172,7 @@ func createServerWithNetwork(svc *Service, name string, network string) (*upclou
 		StorageDevices: []request.CreateServerStorageDevice{
 			{
 				Action:  request.CreateServerStorageDeviceActionClone,
-				Storage: "01000000-0000-4000-8000-000030060200",
+				Storage: "01000000-0000-4000-8000-000030080200",
 				Title:   "disk1",
 				Size:    30,
 				Tier:    upcloud.StorageTierMaxIOPS,


### PR DESCRIPTION
BREAKING CHANGE: This PR will break backwards compatibility so after merging, merge #91 and release 4.0.0

- Remove the old 'Router' field from ModifyNetworkRequest, as it was unsalvageable in it's current form and I feel it's better to remove altogether to force former users to use the new approach
- Implement AttachNetworkRouter and DetachNetworkRouter (and related request types) that actually work
- fixes a network related test and updates it's fixtures