### PR TITLE
fix(test): use ioutil.Tempfile in storage test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,4 +12,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.40.0
+          version: v1.40.1

--- a/upcloud/service/storage_test.go
+++ b/upcloud/service/storage_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -353,16 +352,18 @@ func TestDirectUploadStorageImport(t *testing.T) {
 		sum := sha256.Sum256(buf)
 		sha256sum := hex.EncodeToString(sum[:])
 
-		err = ioutil.WriteFile(path.Join(os.TempDir(), "temp_file.txt"), buf, 0600)
+		tempf, err := ioutil.TempFile(os.TempDir(), "temp_file.txt")
 		require.NoError(t, err)
 		defer func() {
-			os.Remove(path.Join(os.TempDir(), "temp_file.txt"))
+			if err := tempf.Close(); err == nil {
+				os.Remove(tempf.Name())
+			}
 		}()
 
 		_, err = svc.CreateStorageImport(&request.CreateStorageImportRequest{
 			StorageUUID:    storage.UUID,
 			Source:         upcloud.StorageImportSourceDirectUpload,
-			SourceLocation: path.Join(os.TempDir(), "temp_file.txt"),
+			SourceLocation: tempf.Name(),
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Fixes `File creation in shared tmp directory without using ioutil.Tempfile (gosec)` linting error