### PR TITLE
feat(client): new debug flag for setting custom base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - add experimental support for Server Groups
+- add possibility to overwrite default API URL with `UPCLOUD_DEBUG_API_BASE_URL` environment variable
 
 ## [4.4.2]
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ testing so you don't accidentally delete or your production resources!
 
 You can skip running the integration tests and just run the unit tests by passing `-short` to the test command.
 
+## Debugging
+
+Environment variables `UPCLOUD_DEBUG_API_BASE_URL` and `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` can be used for HTTP client debugging purposes.
+
 ## License
 
 This client is distributed under the [MIT License](https://opensource.org/licenses/MIT), see LICENSE.txt for more information.

--- a/upcloud/client/client_test.go
+++ b/upcloud/client/client_test.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientBaseURL(t *testing.T) {
+	assert.Equal(t, DefaultAPIBaseURL, clientBaseURL(""))
+	assert.Equal(t, DefaultAPIBaseURL, clientBaseURL("127.0.0.1"))
+	assert.Equal(t, DefaultAPIBaseURL, clientBaseURL("http://"))
+	assert.Equal(t, "http://127.0.0.1", clientBaseURL("http://127.0.0.1"))
+	assert.Equal(t, "https://127.0.0.1", clientBaseURL("https://127.0.0.1"))
+}


### PR DESCRIPTION
Add new env debug flag `UPCLOUD_DEBUG_API_BASE_URL` to customize API base URL.