### PR TITLE
fix(dbaas) maintenance window empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Expose `GetZones` through `Zones` interface
+- allow time or day of week to be empty in Managed Database maintenance request property
 
 ## [4.5.0]
 

--- a/upcloud/request/managed_database.go
+++ b/upcloud/request/managed_database.go
@@ -59,7 +59,7 @@ func (c CloneManagedDatabaseRequest) MarshalJSON() ([]byte, error) {
 	if !req.alias.CloneTime.IsZero() {
 		req.CloneTime = &req.alias.CloneTime
 	}
-	if c.Maintenance.Time != "" && c.Maintenance.DayOfWeek != "" {
+	if c.Maintenance.Time != "" || c.Maintenance.DayOfWeek != "" {
 		req.Maintenance = &c.Maintenance
 	}
 	return json.Marshal(&req)
@@ -88,7 +88,7 @@ func (c CreateManagedDatabaseRequest) MarshalJSON() ([]byte, error) {
 		alias
 		Maintenance *ManagedDatabaseMaintenanceTimeRequest `json:"maintenance,omitempty"`
 	}{alias: alias(c)}
-	if c.Maintenance.Time != "" && c.Maintenance.DayOfWeek != "" {
+	if c.Maintenance.Time != "" || c.Maintenance.DayOfWeek != "" {
 		req.Maintenance = &c.Maintenance
 	}
 	return json.Marshal(&req)
@@ -388,8 +388,7 @@ func (m ModifyManagedDatabaseRequest) MarshalJSON() ([]byte, error) {
 		alias
 		Maintenance *ManagedDatabaseMaintenanceTimeRequest `json:"maintenance,omitempty"`
 	}{alias: alias(m)}
-
-	if m.Maintenance.Time != "" && m.Maintenance.DayOfWeek != "" {
+	if m.Maintenance.Time != "" || m.Maintenance.DayOfWeek != "" {
 		req.Maintenance = &m.Maintenance
 	}
 	return json.Marshal(&req)

--- a/upcloud/request/managed_database_test.go
+++ b/upcloud/request/managed_database_test.go
@@ -416,3 +416,70 @@ func TestDeleteManagedDatabaseLogicalDatabaseRequest_RequestURL(t *testing.T) {
 	req := DeleteManagedDatabaseLogicalDatabaseRequest{ServiceUUID: "fakeuuid", Name: "fakedb"}
 	assert.Equal(t, "/database/fakeuuid/databases/fakedb", req.RequestURL())
 }
+
+func TestCreateManagedDatabaseRequestMaintenanceTime_MarshalJSON(t *testing.T) {
+	req := CreateManagedDatabaseRequest{
+		HostNamePrefix: "fakename",
+		Plan:           "fakeplan",
+		Title:          "faketitle",
+		Type:           "faketype",
+		Zone:           "fakezone",
+	}
+	req.Maintenance = ManagedDatabaseMaintenanceTimeRequest{
+		DayOfWeek: "monday",
+		Time:      "12:00:00",
+	}
+	d, err := json.Marshal(&req)
+	assert.NoError(t, err)
+	expect := `
+	{
+		"hostname_prefix": "fakename",
+		"plan": "fakeplan",
+		"title": "faketitle",
+		"type": "faketype",
+		"zone": "fakezone",
+		"maintenance": {
+			"dow": "monday",
+			"time": "12:00:00"
+		}
+	}`
+	assert.JSONEq(t, expect, string(d))
+
+	// Without maintenance time
+	req.Maintenance = ManagedDatabaseMaintenanceTimeRequest{
+		DayOfWeek: "monday",
+	}
+	d, err = json.Marshal(&req)
+	assert.NoError(t, err)
+	expect = `
+	{
+		"hostname_prefix": "fakename",
+		"plan": "fakeplan",
+		"title": "faketitle",
+		"type": "faketype",
+		"zone": "fakezone",
+		"maintenance": {
+			"dow": "monday"
+		}
+	}`
+	assert.JSONEq(t, expect, string(d))
+
+	// Without maintenance dow
+	req.Maintenance = ManagedDatabaseMaintenanceTimeRequest{
+		Time: "12:00:00",
+	}
+	d, err = json.Marshal(&req)
+	assert.NoError(t, err)
+	expect = `
+	{
+		"hostname_prefix": "fakename",
+		"plan": "fakeplan",
+		"title": "faketitle",
+		"type": "faketype",
+		"zone": "fakezone",
+		"maintenance": {
+			"time": "12:00:00"
+		}
+	}`
+	assert.JSONEq(t, expect, string(d))
+}


### PR DESCRIPTION
Fixes maintenance property not sent if either time or dow is empty
when creating database.