### PR TITLE
feat(client-context): disable default timeout

### DIFF
--- a/upcloud/client/client_ctx.go
+++ b/upcloud/client/client_ctx.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 )
 
 // ClientContext represents an API client with context support
@@ -71,11 +72,19 @@ func (c *ClientContext) PerformJSONRequest(ctx context.Context, method, url stri
 
 // NewWithContext creates ands returns a new client with context support configured with the specified user and password
 func NewWithContext(userName, password string) *ClientContext {
-	return &ClientContext{New(userName, password)}
+	return NewWithHTTPClientContext(userName, password, httpClient())
 }
 
 // NewWithHTTPClientContext creates ands returns a new client with context support configured with the specified user and password and
 // using a supplied `http.Client`.
 func NewWithHTTPClientContext(userName string, password string, httpClient *http.Client) *ClientContext {
-	return &ClientContext{NewWithHTTPClient(userName, password, httpClient)}
+	return &ClientContext{
+		&Client{
+			userName:   userName,
+			password:   password,
+			httpClient: httpClient,
+			baseURL:    clientBaseURL(os.Getenv(EnvDebugAPIBaseURL)),
+			UserAgent:  userAgent(),
+		},
+	}
 }

--- a/upcloud/client/client_ctx_test.go
+++ b/upcloud/client/client_ctx_test.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	globals "github.com/UpCloudLtd/upcloud-go-api/v4/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientContextTimeout(t *testing.T) {
+	var u, p string
+	c1 := NewWithContext(u, p)
+	assert.Equal(t, time.Duration(0), c1.GetTimeout())
+	c2 := NewWithHTTPClientContext(u, p, http.DefaultClient)
+	assert.Equal(t, time.Duration(0), c2.GetTimeout())
+}
+
+func TestClientContextUserAgent(t *testing.T) {
+	var u, p string
+	c1 := NewWithContext(u, p)
+	assert.Equal(t, fmt.Sprintf("upcloud-go-api/%s", globals.Version), c1.UserAgent)
+}

--- a/upcloud/client/client_test.go
+++ b/upcloud/client/client_test.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	globals "github.com/UpCloudLtd/upcloud-go-api/v4/internal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +17,20 @@ func TestClientBaseURL(t *testing.T) {
 	assert.Equal(t, DefaultAPIBaseURL, clientBaseURL("http://"))
 	assert.Equal(t, "http://127.0.0.1", clientBaseURL("http://127.0.0.1"))
 	assert.Equal(t, "https://127.0.0.1", clientBaseURL("https://127.0.0.1"))
+}
+
+func TestClientTimeout(t *testing.T) {
+	var u, p string
+	c1 := New(u, p)
+	assert.Equal(t, time.Second*DefaultTimeout, c1.GetTimeout())
+	c2 := NewWithHTTPClient(u, p, http.DefaultClient)
+	assert.Equal(t, time.Second*DefaultTimeout, c2.GetTimeout())
+}
+
+func TestClientUserAgent(t *testing.T) {
+	var u, p string
+	c1 := New(u, p)
+	assert.Equal(t, fmt.Sprintf("upcloud-go-api/%s", globals.Version), c1.UserAgent)
 }
 
 func ExampleNew() {


### PR DESCRIPTION
Disable default timeout when using context aware client
as it might result in unexpected behaviour when using context cancellation.