### PR TITLE
refactor(errors): custom unmarshaler

### DIFF
--- a/upcloud/error_test.go
+++ b/upcloud/error_test.go
@@ -1,60 +1,69 @@
 package upcloud
 
 import (
-	"encoding/json"
+	"net/http"
 	"testing"
 
+	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/client"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrorLegacyUnmarshal(t *testing.T) {
-	originalJSON := `
-        {
-            "error": {
-              "error_message": "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.",
-              "error_code": "SERVER_NOT_FOUND"
-            }
-        }
-    `
+func TestNewError(t *testing.T) {
+	rawErr := NewError(&client.Error{
+		Type:      client.ErrorTypeError,
+		ErrorCode: http.StatusNotFound,
+		ResponseBody: []byte(`
+			{
+				"error": {
+				  "error_message": "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.",
+				  "error_code": "SERVER_NOT_FOUND"
+				}
+			}
+		`),
+	})
 
-	e := Error{}
-	err := json.Unmarshal([]byte(originalJSON), &e)
-	assert.NoError(t, err)
-	assert.Equal(t, "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.", e.Message)
-	assert.Equal(t, "SERVER_NOT_FOUND", e.Code)
-	assert.Nil(t, e.problemError)
+	// fmt.Printf("\033[33m Err: %s \033[0m\n", rawErr.Error())
+
+	err, ok := rawErr.(*Error)
+	assert.True(t, ok)
+	assert.Equal(t, "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.", err.Message)
+	assert.Equal(t, "SERVER_NOT_FOUND", err.Code)
+	assert.Nil(t, err.problemError)
 }
 
-func TestErrorProblemUnmarshal(t *testing.T) {
-	originalJSON := `
-		{
-			"type": "https://developers.upcloud.com/1.3/errors#ERROR_INVALID_REQUEST",
-			"title": "Validation error.",
-			"correlation_id": "01GRKDQBGD7FA84MGR9373F093",
-			"invalid_params": [
-				{
-					"name": "plan",
-					"reason": "Plan doesn't exist"
-				}
-			],
-			"status": 400
-		}
-	`
+func TestNewErrorWithProblem(t *testing.T) {
+	rawErr := NewError(&client.Error{
+		Type:      client.ErrorTypeProblem,
+		ErrorCode: http.StatusBadRequest,
+		ResponseBody: []byte(`
+			{
+				"type": "https://developers.upcloud.com/1.3/errors#ERROR_INVALID_REQUEST",
+				"title": "Validation error.",
+				"correlation_id": "01GRKDQBGD7FA84MGR9373F093",
+				"invalid_params": [
+					{
+						"name": "plan",
+						"reason": "Plan doesn't exist"
+					}
+				],
+				"status": 400
+			}
+		`),
+	})
 
-	e := Error{}
-	err := json.Unmarshal([]byte(originalJSON), &e)
-	assert.NoError(t, err)
+	err, ok := rawErr.(*Error)
+	assert.True(t, ok)
 
 	// Check basic (legacy) error properties
-	assert.Equal(t, "INVALID_REQUEST", e.Code)
-	assert.Equal(t, "Validation error.", e.Message)
+	assert.Equal(t, "INVALID_REQUEST", err.Code)
+	assert.Equal(t, "Validation error.", err.Message)
 
 	// Check json+problem properties
-	assert.Equal(t, "Validation error.", e.problemError.Title)
-	assert.Equal(t, "https://developers.upcloud.com/1.3/errors#ERROR_INVALID_REQUEST", e.problemError.Type)
-	assert.Equal(t, "01GRKDQBGD7FA84MGR9373F093", e.problemError.CorrelationID)
-	assert.Equal(t, 400, e.problemError.Status)
-	assert.Len(t, e.problemError.InvalidParams, 1)
-	assert.Equal(t, e.problemError.InvalidParams[0].Name, "plan")
-	assert.Equal(t, e.problemError.InvalidParams[0].Reason, "Plan doesn't exist")
+	assert.Equal(t, "Validation error.", err.problemError.Title)
+	assert.Equal(t, "https://developers.upcloud.com/1.3/errors#ERROR_INVALID_REQUEST", err.problemError.Type)
+	assert.Equal(t, "01GRKDQBGD7FA84MGR9373F093", err.problemError.CorrelationID)
+	assert.Equal(t, 400, err.problemError.Status)
+	assert.Len(t, err.problemError.InvalidParams, 1)
+	assert.Equal(t, err.problemError.InvalidParams[0].Name, "plan")
+	assert.Equal(t, err.problemError.InvalidParams[0].Reason, "Plan doesn't exist")
 }


### PR DESCRIPTION
This PR has an alternative approach to unamrshaling unified API error in SDK.
It assumes that by the time we get to unmarshaling, the `Error.clientError` should be already set.
This allows to make the unamrshaling logic a bit nicer and less hacky.
The downside is that we cannot really unmarshal the struct itself - because it needs the `clientError` field to be not nil, and that field is private, thus it cannot be set outside of `upcloud` package. So unmarshaling can only really happen in the `NewError` function, which might not be the end of the world, but it sucks.
Overall I don't like this approach due to ☝️ this limitation, but the logic looks nicer.