### PR TITLE
feat(config): tls config: skip verify for provided client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+- client: overwriting the Transport of the provided HTTP Client when `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` environment variable is set to `1`
+
 ## [6.0.0]
 
 ### Added


### PR DESCRIPTION
upcloud-go-api consumers may define and provide their own HTTP Client while initializing the client. With this change, the debug environment variable `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` is respected regardless of the source of the HTTP Client.

Previously, if a consumer provided a client, the transport was unaffected even if `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` was set to `1` and skipping TLS verification was not enabled.