### PR TITLE
feat(server): add option to delete backups while deleting server and …

### DIFF
--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -361,10 +361,28 @@ func (r *DeleteServerRequest) RequestURL() string {
 // DeleteServerAndStoragesRequest represents a request to delete a server and all attached storages
 type DeleteServerAndStoragesRequest struct {
 	UUID string
+
+	// DeleteBackups indicates if backups should be deleted along with the server and storages
+	DeleteBackups bool
+
+	// KeepLatestBackups indicates if the latest backup should be kept;
+	// only relevant if `DeleteBackups` field is set to true
+	KeepLatestBackup bool
 }
 
 // RequestURL implements the Request interface
 func (r *DeleteServerAndStoragesRequest) RequestURL() string {
+	if r.DeleteBackups {
+		backups := "delete"
+
+		if r.KeepLatestBackup {
+			backups = "keep_latest"
+		}
+
+		return fmt.Sprintf("/server/%s/?storages=1&backups=%s", r.UUID, backups)
+	}
+
+	// Default for backups is "keep", so we don't need to add that parameter to request URL if we don't delete backups
 	return fmt.Sprintf("/server/%s/?storages=1", r.UUID)
 }
 

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -356,6 +356,21 @@ func TestDeleteServerAndStoragesRequest(t *testing.T) {
 	}
 
 	assert.Equal(t, "/server/foo/?storages=1", request.RequestURL())
+
+	request = DeleteServerAndStoragesRequest{
+		UUID:          "bar",
+		DeleteBackups: true,
+	}
+
+	assert.Equal(t, "/server/bar/?storages=1&backups=delete", request.RequestURL())
+
+	request = DeleteServerAndStoragesRequest{
+		UUID:             "baz",
+		DeleteBackups:    true,
+		KeepLatestBackup: true,
+	}
+
+	assert.Equal(t, "/server/baz/?storages=1&backups=keep_latest", request.RequestURL())
 }
 
 // TestTagServerRequest tests that TestTagServer behaves correctly


### PR DESCRIPTION
This PR adds two new fields to `DeleteServerAndStoragesRequest` struct, that allow also deleting backups.