### PR TITLE
chore(server): add constants for NIC models

### DIFF
--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -14,6 +14,10 @@ const (
 	VideoModelVGA    = "vga"
 	VideoModelCirrus = "cirrus"
 
+	NICModelE1000   = "e1000"
+	NICModelVirtio  = "virtio"
+	NICModelRTL8139 = "rtl8139"
+
 	StopTypeSoft = "soft"
 	StopTypeHard = "hard"
 

--- a/upcloud/server_test.go
+++ b/upcloud/server_test.go
@@ -254,7 +254,7 @@ func TestUnmarshalServerDetails(t *testing.T) {
 	assert.Len(t, serverDetails.IPAddresses, 3)
 	assert.Equal(t, "managedBy", serverDetails.Labels[0].Key)
 	assert.Equal(t, "upcloud-go-sdk-unit-test", serverDetails.Labels[0].Value)
-	assert.Equal(t, "virtio", serverDetails.NICModel)
+	assert.Equal(t, NICModelVirtio, serverDetails.NICModel)
 	assert.Len(t, serverDetails.StorageDevices, 1)
 	assert.Equal(t, "012580a1-32a1-466e-a323-689ca16f2d43", serverDetails.StorageDevices[0].UUID)
 	assert.Equal(t, "virtio:0", serverDetails.StorageDevices[0].Address)


### PR DESCRIPTION
Add constants for NIC models as defined in [the API spec](https://developers.upcloud.com/1.3/8-servers/#attributes).