### PR TITLE
chore(server): add NIC model attribute to server related calls

### DIFF
--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -144,6 +144,7 @@ type CreateServerRequest struct {
 	LoginUser            *LoginUser                     `json:"login_user,omitempty"`
 	MemoryAmount         int                            `json:"memory_amount,omitempty"`
 	Metadata             upcloud.Boolean                `json:"metadata"`
+	NICModel             string                         `json:"nic_model"`
 	Networking           *CreateServerNetworking        `json:"networking"`
 	PasswordDelivery     string                         `json:"password_delivery,omitempty"`
 	Plan                 string                         `json:"plan,omitempty"`
@@ -320,6 +321,7 @@ type ModifyServerRequest struct {
 	Labels               *upcloud.LabelSlice `json:"labels,omitempty"`
 	MemoryAmount         int                 `json:"memory_amount,omitempty,string"`
 	Metadata             upcloud.Boolean     `json:"metadata"`
+	NICModel             string              `json:"string"`
 	Plan                 string              `json:"plan,omitempty"`
 	SimpleBackup         string              `json:"simple_backup,omitempty"`
 	TimeZone             string              `json:"timezone,omitempty"`

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -321,7 +321,7 @@ type ModifyServerRequest struct {
 	Labels               *upcloud.LabelSlice `json:"labels,omitempty"`
 	MemoryAmount         int                 `json:"memory_amount,omitempty,string"`
 	Metadata             upcloud.Boolean     `json:"metadata"`
-	NICModel             string              `json:"string"`
+	NICModel             string              `json:"nic_model,omitempty"`
 	Plan                 string              `json:"plan,omitempty"`
 	SimpleBackup         string              `json:"simple_backup,omitempty"`
 	TimeZone             string              `json:"timezone,omitempty"`

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -144,7 +144,7 @@ type CreateServerRequest struct {
 	LoginUser            *LoginUser                     `json:"login_user,omitempty"`
 	MemoryAmount         int                            `json:"memory_amount,omitempty"`
 	Metadata             upcloud.Boolean                `json:"metadata"`
-	NICModel             string                         `json:"nic_model"`
+	NICModel             string                         `json:"nic_model,omitempty"`
 	Networking           *CreateServerNetworking        `json:"networking"`
 	PasswordDelivery     string                         `json:"password_delivery,omitempty"`
 	Plan                 string                         `json:"plan,omitempty"`

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -67,6 +67,7 @@ func TestCreateServerRequest(t *testing.T) {
 			},
 		},
 		Metadata: upcloud.True,
+		NICModel: upcloud.NICModelVirtio,
 		Networking: &CreateServerNetworking{
 			Interfaces: []CreateServerInterface{
 				{
@@ -143,6 +144,7 @@ func TestCreateServerRequest(t *testing.T) {
 					]
 			 },
 			 "metadata":"yes",
+			 "nic_model":"virtio",
 			 "networking":{
 					"interfaces":{
 						 "interface":[


### PR DESCRIPTION
Add `nic_model` parameter to create and modify server requests. Already present in `ServerDetails`. This will allow clients to define a custom `nic_model` upon server creation or modification.