### PR TITLE
feat(lbaas): support for controlling health check TLS verify

### DIFF
--- a/upcloud/load_balancer.go
+++ b/upcloud/load_balancer.go
@@ -198,6 +198,7 @@ type LoadBalancerBackendMember struct {
 type LoadBalancerBackendProperties struct {
 	TimeoutServer             int                              `json:"timeout_server,omitempty"`
 	TimeoutTunnel             int                              `json:"timeout_tunnel,omitempty"`
+	HealthCheckTLSVerify      *bool                            `json:"health_check_tls_verify,omitempty"`
 	HealthCheckType           LoadBalancerHealthCheckType      `json:"health_check_type,omitempty"`
 	HealthCheckInterval       int                              `json:"health_check_interval,omitempty"`
 	HealthCheckFall           int                              `json:"health_check_fall,omitempty"`

--- a/upcloud/load_balancer_test.go
+++ b/upcloud/load_balancer_test.go
@@ -507,6 +507,7 @@ func TestLoadBalancerBackendProperties(t *testing.T) {
 		&LoadBalancerBackendProperties{
 			TimeoutServer:             30,
 			TimeoutTunnel:             3600,
+			HealthCheckTLSVerify:      BoolPtr(false),
 			HealthCheckType:           LoadBalancerHealthCheckTypeHTTP,
 			HealthCheckInterval:       20,
 			HealthCheckFall:           3,
@@ -521,6 +522,7 @@ func TestLoadBalancerBackendProperties(t *testing.T) {
 			"timeout_server": 30,
 			"timeout_tunnel": 3600,
 			"health_check_type": "http",
+			"health_check_tls_verify": false,
 			"health_check_interval": 20,
 			"health_check_fall": 3,
 			"health_check_rise": 3,

--- a/upcloud/service/fixtures/loadbalancer.yaml
+++ b/upcloud/service/fixtures/loadbalancer.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1648826267","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"172.16.1.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686161426","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"172.16.1.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1648826267",
+            "labels" : [],
+            "name" : "go-test-lb-1686161426",
             "type" : "private",
-            "uuid" : "031c09fe-98bd-4504-83c8-0583f52ef7d9",
+            "uuid" : "03c2e1f3-13b6-4891-92f8-995195c9e2a3",
             "zone" : "fi-hel1"
          }
       }
     headers:
       Content-Length:
-      - "463"
+      - "484"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 01 Apr 2022 15:17:47 GMT
+      - Wed, 07 Jun 2023 18:10:26 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel1-1648826268","plan":"development","zone":"fi-hel1","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel1-1686161427","plan":"development","zone":"fi-hel1","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,18 +58,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel1-1648826268","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.105034Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"go-test-lb-fi-hel1-1686161427","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.391155Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "431"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -83,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: PATCH
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.185847Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.587302Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "417"
+      - "1018"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -109,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.185847Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.599554Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "417"
+      - "1018"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -135,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=100&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.185847Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.599554Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}]'
     headers:
       Content-Length:
-      - "419"
+      - "1020"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -161,14 +162,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -183,18 +184,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.332772Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.943516Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "417"
+      - "1018"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:48 GMT
+      - Wed, 07 Jun 2023 18:10:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -209,18 +210,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.332772Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.943516Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "417"
+      - "1018"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:50 GMT
+      - Wed, 07 Jun 2023 18:10:30 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -235,18 +236,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:48.332772Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:27.943516Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "417"
+      - "1018"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:52 GMT
+      - Wed, 07 Jun 2023 18:10:32 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -261,18 +262,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:54 GMT
+      - Wed, 07 Jun 2023 18:10:34 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -287,18 +288,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:56 GMT
+      - Wed, 07 Jun 2023 18:10:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -313,18 +314,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:17:58 GMT
+      - Wed, 07 Jun 2023 18:10:38 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -339,18 +340,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:00 GMT
+      - Wed, 07 Jun 2023 18:10:40 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -365,18 +366,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:02 GMT
+      - Wed, 07 Jun 2023 18:10:42 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -391,18 +392,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:04 GMT
+      - Wed, 07 Jun 2023 18:10:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -417,18 +418,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:06 GMT
+      - Wed, 07 Jun 2023 18:10:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -443,18 +444,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:09 GMT
+      - Wed, 07 Jun 2023 18:10:49 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -469,18 +470,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:11 GMT
+      - Wed, 07 Jun 2023 18:10:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -495,18 +496,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:13 GMT
+      - Wed, 07 Jun 2023 18:10:53 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -521,18 +522,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:15 GMT
+      - Wed, 07 Jun 2023 18:10:55 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -547,18 +548,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:17 GMT
+      - Wed, 07 Jun 2023 18:10:57 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -573,18 +574,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:19 GMT
+      - Wed, 07 Jun 2023 18:11:00 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -599,18 +600,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:21 GMT
+      - Wed, 07 Jun 2023 18:11:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -625,18 +626,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:23 GMT
+      - Wed, 07 Jun 2023 18:11:04 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -651,18 +652,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:25 GMT
+      - Wed, 07 Jun 2023 18:11:06 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -677,18 +678,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:27 GMT
+      - Wed, 07 Jun 2023 18:11:08 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -703,18 +704,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:29 GMT
+      - Wed, 07 Jun 2023 18:11:10 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -729,18 +730,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:31 GMT
+      - Wed, 07 Jun 2023 18:11:13 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -755,18 +756,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:33 GMT
+      - Wed, 07 Jun 2023 18:11:15 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -781,18 +782,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T15:17:48.105034Z","dns_name":"lb-0a79267ad4f447d0bb8d8ae79108e9c7.upcloudlb.com","frontends":[],"name":"new-name-for-lb","network_uuid":"031c09fe-98bd-4504-83c8-0583f52ef7d9","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T15:17:54.382935Z","uuid":"0a79267a-d4f4-47d0-bb8d-8ae79108e9c7","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "423"
+      - "1024"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 15:18:35 GMT
+      - Wed, 07 Jun 2023 18:11:17 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -807,12 +808,272 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a79267a-d4f4-47d0-bb8d-8ae79108e9c7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:21 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:27 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:30 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:32 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:34 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:36 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:20:29Z","name":"new-name-for-lb","network_uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3","networks":[{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:10:27.391155Z"},{"created_at":"2023-06-07T18:10:27.391155Z","dns_name":"lb-0a5955c8e31a447e86e77ecab95a6ab8-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:10:27.391155Z","uuid":"03c2e1f3-13b6-4891-92f8-995195c9e2a3"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:10:33.088485Z","uuid":"0a5955c8-e31a-447e-86e7-7ecab95a6ab8","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1024"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:11:38 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a5955c8-e31a-447e-86e7-7ecab95a6ab8
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJV9YXD36DD0YF3X72KHXYB","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BGXAEBA1SWDSNFWVMH3HM7","status":404}
     headers:
       Content-Language:
       - en
@@ -821,7 +1082,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 15:18:37 GMT
+      - Wed, 07 Jun 2023 18:11:40 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -836,14 +1097,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/network/031c09fe-98bd-4504-83c8-0583f52ef7d9
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03c2e1f3-13b6-4891-92f8-995195c9e2a3
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 15:18:37 GMT
+      - Wed, 07 Jun 2023 18:11:40 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/loadbalancerbackend.yaml
+++ b/upcloud/service/fixtures/loadbalancerbackend.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1654854028","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.2.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686161530","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.2.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1654854028",
+            "labels" : [],
+            "name" : "go-test-lb-1686161530",
             "type" : "private",
-            "uuid" : "03d407ac-22e0-4915-88f8-66c6ea35ead7",
+            "uuid" : "03e72224-bf28-4533-a26a-3668fc4e6fe1",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "463"
+      - "484"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 10 Jun 2022 09:40:28 GMT
+      - Wed, 07 Jun 2023 18:12:10 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1654854028","plan":"development","zone":"fi-hel2","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686161531","plan":"development","zone":"fi-hel2","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,25 +58,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:28.942054Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:11.251493Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "989"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:28 GMT
+      - Wed, 07 Jun 2023 18:12:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-backend-1654854028","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}],"properties":{"timeout_server":30}}'
+    body: '{"name":"go-test-lb-backend-1686161531","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}],"properties":{"timeout_server":30}}'
     form: {}
     headers:
       Accept:
@@ -83,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c/backends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e/backends
     method: POST
   response:
-    body: '{"created_at":"2022-06-10T09:40:29.044816Z","members":[{"created_at":"2022-06-10T09:40:29.044816Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:40:29.044816Z","weight":100}],"name":"go-test-lb-backend-1654854028","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:40:29.044816Z"}'
+    body: '{"created_at":"2023-06-07T18:12:11.424842Z","members":[{"created_at":"2023-06-07T18:12:11.424842Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:12:11.424842Z","weight":100}],"name":"go-test-lb-backend-1686161531","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:12:11.424842Z"}'
     headers:
       Content-Length:
-      - "605"
+      - "680"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:29 GMT
+      - Wed, 07 Jun 2023 18:12:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -109,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c/backends/go-test-lb-backend-1654854028
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e/backends/go-test-lb-backend-1686161531
     method: PATCH
   response:
-    body: '{"created_at":"2022-06-10T09:40:29.044816Z","members":[{"created_at":"2022-06-10T09:40:29.044816Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:40:29.044816Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:40:31.003308Z"}'
+    body: '{"created_at":"2023-06-07T18:12:11.424842Z","members":[{"created_at":"2023-06-07T18:12:11.424842Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:12:11.601615Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:12:11.601615Z"}'
     headers:
       Content-Length:
-      - "587"
+      - "662"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -135,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c/backends/updatedName
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e/backends/updatedName
     method: GET
   response:
-    body: '{"created_at":"2022-06-10T09:40:29.044816Z","members":[{"created_at":"2022-06-10T09:40:29.044816Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:40:29.044816Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:40:31.003308Z"}'
+    body: '{"created_at":"2023-06-07T18:12:11.424842Z","members":[{"created_at":"2023-06-07T18:12:11.424842Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:12:11.601615Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:12:11.601615Z"}'
     headers:
       Content-Length:
-      - "587"
+      - "662"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -161,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c/backends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e/backends
     method: GET
   response:
-    body: '[{"created_at":"2022-06-10T09:40:29.044816Z","members":[{"created_at":"2022-06-10T09:40:29.044816Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:40:29.044816Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:40:31.003308Z"}]'
+    body: '[{"created_at":"2023-06-07T18:12:11.424842Z","members":[{"created_at":"2023-06-07T18:12:11.424842Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:12:11.601615Z","weight":100}],"name":"updatedName","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:12:11.601615Z"}]'
     headers:
       Content-Length:
-      - "589"
+      - "664"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -187,14 +188,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c/backends/updatedName
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e/backends/updatedName
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:12 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -209,14 +210,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:12 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -231,18 +232,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:31 GMT
+      - Wed, 07 Jun 2023 18:12:12 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -257,18 +258,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:33 GMT
+      - Wed, 07 Jun 2023 18:12:14 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -283,18 +284,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:35 GMT
+      - Wed, 07 Jun 2023 18:12:16 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -309,18 +310,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:37 GMT
+      - Wed, 07 Jun 2023 18:12:18 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -335,18 +336,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:39 GMT
+      - Wed, 07 Jun 2023 18:12:20 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -361,18 +362,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:41 GMT
+      - Wed, 07 Jun 2023 18:12:23 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -387,18 +388,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:43 GMT
+      - Wed, 07 Jun 2023 18:12:25 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -413,18 +414,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:12.143002Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1034"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:45 GMT
+      - Wed, 07 Jun 2023 18:12:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -439,18 +440,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:47 GMT
+      - Wed, 07 Jun 2023 18:12:29 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -465,18 +466,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:49 GMT
+      - Wed, 07 Jun 2023 18:12:31 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -491,18 +492,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:51 GMT
+      - Wed, 07 Jun 2023 18:12:33 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -517,18 +518,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:53 GMT
+      - Wed, 07 Jun 2023 18:12:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -543,18 +544,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:56 GMT
+      - Wed, 07 Jun 2023 18:12:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -569,18 +570,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:40:58 GMT
+      - Wed, 07 Jun 2023 18:12:40 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -595,18 +596,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:00 GMT
+      - Wed, 07 Jun 2023 18:12:42 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -621,18 +622,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:02 GMT
+      - Wed, 07 Jun 2023 18:12:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -647,18 +648,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:04 GMT
+      - Wed, 07 Jun 2023 18:12:46 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -673,18 +674,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:06 GMT
+      - Wed, 07 Jun 2023 18:12:48 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -699,18 +700,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:08 GMT
+      - Wed, 07 Jun 2023 18:12:50 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -725,18 +726,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:40:28.942054Z","dns_name":"lb-0a51eb8b8344422cb364782f3c86c69c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1654854028","network_uuid":"03d407ac-22e0-4915-88f8-66c6ea35ead7","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:40:31.371851Z","uuid":"0a51eb8b-8344-422c-b364-782f3c86c69c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:41:10 GMT
+      - Wed, 07 Jun 2023 18:12:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -751,12 +752,168 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a51eb8b-8344-422c-b364-782f3c86c69c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:12:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:12:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:12:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:13:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:13:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"01:49:07Z","name":"go-test-lb-fi-hel2-1686161531","network_uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1","networks":[{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:12:11.251493Z"},{"created_at":"2023-06-07T18:12:11.251493Z","dns_name":"lb-0a33688ecca44259a14d81e49b13570e-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:12:11.251493Z","uuid":"03e72224-bf28-4533-a26a-3668fc4e6fe1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:12:27.939949Z","uuid":"0a33688e-cca4-4259-a14d-81e49b13570e","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:13:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33688e-cca4-4259-a14d-81e49b13570e
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01G56FTE3WQNEM7JPM502Z6KV8","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BGZZGVHB2BFW8B7VRPSQGW","status":404}
     headers:
       Content-Language:
       - en
@@ -765,7 +922,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 10 Jun 2022 09:41:12 GMT
+      - Wed, 07 Jun 2023 18:13:07 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -780,14 +937,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/network/03d407ac-22e0-4915-88f8-66c6ea35ead7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03e72224-bf28-4533-a26a-3668fc4e6fe1
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:41:12 GMT
+      - Wed, 07 Jun 2023 18:13:07 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/loadbalancerbackendmember.yaml
+++ b/upcloud/service/fixtures/loadbalancerbackendmember.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1649160313","zone":"nl-ams1","ip_networks":{"ip_network":[{"address":"172.16.3.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686161605","zone":"nl-ams1","ip_networks":{"ip_network":[{"address":"172.16.3.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1649160313",
+            "labels" : [],
+            "name" : "go-test-lb-1686161605",
             "type" : "private",
-            "uuid" : "03dc285d-4517-4ffe-922e-593b02fa5196",
+            "uuid" : "03bcd448-8480-47a7-a1b9-f155e9e0c914",
             "zone" : "nl-ams1"
          }
       }
     headers:
       Content-Length:
-      - "463"
+      - "484"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 05 Apr 2022 12:05:13 GMT
+      - Wed, 07 Jun 2023 18:13:25 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-nl-ams1-1649160314","plan":"development","zone":"nl-ams1","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-nl-ams1-1686161606","plan":"development","zone":"nl-ams1","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,25 +58,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:14.301917Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:26.574898Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "431"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:26 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-backend-1649160314","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}]}'
+    body: '{"name":"go-test-lb-backend-1686161606","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}],"properties":{"timeout_server":30}}'
     form: {}
     headers:
       Accept:
@@ -83,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends
     method: POST
   response:
-    body: '{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}'
+    body: '{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "680"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:26 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -109,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members
     method: POST
   response:
-    body: '{"created_at":"2022-04-05T12:05:14.44572Z","enabled":true,"ip":"10.0.0.2","max_sessions":123,"name":"test_member","port":80,"type":"static","updated_at":"2022-04-05T12:05:14.44572Z","weight":100}'
+    body: '{"created_at":"2023-06-07T18:13:26.936217Z","enabled":true,"ip":"10.0.0.2","max_sessions":123,"name":"test_member","port":80,"type":"static","updated_at":"2023-06-07T18:13:26.936217Z","weight":100}'
     headers:
       Content-Length:
-      - "195"
+      - "197"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:26 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -135,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members/test_member
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members/test_member
     method: PATCH
   response:
-    body: '{"created_at":"2022-04-05T12:05:14.44572Z","enabled":true,"ip":"10.0.0.2","max_sessions":321,"name":"test_member_TURBO","port":80,"type":"static","updated_at":"2022-04-05T12:05:14.508247Z","weight":50}'
+    body: '{"created_at":"2023-06-07T18:13:26.936217Z","enabled":true,"ip":"10.0.0.2","max_sessions":321,"name":"test_member_TURBO","port":80,"type":"static","updated_at":"2023-06-07T18:13:27.222035Z","weight":50}'
     headers:
       Content-Length:
-      - "201"
+      - "202"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -161,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members/test_member_TURBO
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members/test_member_TURBO
     method: PATCH
   response:
-    body: '{"created_at":"2022-04-05T12:05:14.44572Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2022-04-05T12:05:14.569465Z","weight":50}'
+    body: '{"created_at":"2023-06-07T18:13:26.936217Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2023-06-07T18:13:27.586853Z","weight":50}'
     headers:
       Content-Length:
-      - "210"
+      - "211"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -187,18 +188,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members/test_member_TURBO
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members/test_member_TURBO
     method: GET
   response:
-    body: '{"created_at":"2022-04-05T12:05:14.44572Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2022-04-05T12:05:14.569465Z","weight":50}'
+    body: '{"created_at":"2023-06-07T18:13:26.936217Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2023-06-07T18:13:27.586853Z","weight":50}'
     headers:
       Content-Length:
-      - "210"
+      - "211"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -213,18 +214,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members
     method: GET
   response:
-    body: '[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100},{"created_at":"2022-04-05T12:05:14.44572Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2022-04-05T12:05:14.569465Z","weight":50}]'
+    body: '[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100},{"created_at":"2023-06-07T18:13:26.936217Z","enabled":true,"ip":"231.231.231.231","max_sessions":321,"name":"test_member_TURBO","port":3003,"type":"static","updated_at":"2023-06-07T18:13:27.586853Z","weight":50}]'
     headers:
       Content-Length:
-      - "435"
+      - "436"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -239,14 +240,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7/backends/go-test-lb-backend-1649160314/members/test_member_TURBO
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f/backends/go-test-lb-backend-1686161606/members/test_member_TURBO
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -261,14 +262,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -283,18 +284,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:14.770207Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "849"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:14 GMT
+      - Wed, 07 Jun 2023 18:13:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -309,18 +310,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:14.770207Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "849"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:16 GMT
+      - Wed, 07 Jun 2023 18:13:30 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -335,18 +336,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:14.770207Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "849"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:18 GMT
+      - Wed, 07 Jun 2023 18:13:32 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -361,18 +362,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:20 GMT
+      - Wed, 07 Jun 2023 18:13:34 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -387,18 +388,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:23 GMT
+      - Wed, 07 Jun 2023 18:13:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -413,18 +414,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:25 GMT
+      - Wed, 07 Jun 2023 18:13:39 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -439,18 +440,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:27 GMT
+      - Wed, 07 Jun 2023 18:13:41 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -465,18 +466,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:28.193188Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:29 GMT
+      - Wed, 07 Jun 2023 18:13:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -491,18 +492,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:41.865541Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1712"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:31 GMT
+      - Wed, 07 Jun 2023 18:13:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -517,18 +518,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:33 GMT
+      - Wed, 07 Jun 2023 18:13:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -543,18 +544,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:35 GMT
+      - Wed, 07 Jun 2023 18:13:49 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -569,18 +570,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:37 GMT
+      - Wed, 07 Jun 2023 18:13:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -595,18 +596,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:39 GMT
+      - Wed, 07 Jun 2023 18:13:53 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -621,18 +622,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:41 GMT
+      - Wed, 07 Jun 2023 18:13:56 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -647,18 +648,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:43 GMT
+      - Wed, 07 Jun 2023 18:13:58 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -673,18 +674,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:45 GMT
+      - Wed, 07 Jun 2023 18:14:00 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -699,18 +700,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:47 GMT
+      - Wed, 07 Jun 2023 18:14:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -725,18 +726,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:49 GMT
+      - Wed, 07 Jun 2023 18:14:04 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -751,18 +752,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:51 GMT
+      - Wed, 07 Jun 2023 18:14:06 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -777,18 +778,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:53 GMT
+      - Wed, 07 Jun 2023 18:14:08 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -803,18 +804,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:55 GMT
+      - Wed, 07 Jun 2023 18:14:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -829,18 +830,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:05:57 GMT
+      - Wed, 07 Jun 2023 18:14:13 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -855,18 +856,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T12:05:14.380639Z","members":[{"created_at":"2022-04-05T12:05:14.380639Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-04-05T12:05:14.380639Z","weight":100}],"name":"go-test-lb-backend-1649160314","properties":{"timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-04-05T12:05:14.380639Z"}],"configured_status":"started","created_at":"2022-04-05T12:05:14.301917Z","dns_name":"lb-0af5fe7710f04e2b81d8a10c154a44b7.upcloudlb.com","frontends":[],"name":"go-test-lb-nl-ams1-1649160314","network_uuid":"03dc285d-4517-4ffe-922e-593b02fa5196","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-05T12:05:19.802554Z","uuid":"0af5fe77-10f0-4e2b-81d8-a10c154a44b7","zone":"nl-ams1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
     headers:
       Content-Length:
-      - "855"
+      - "1718"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 12:06:00 GMT
+      - Wed, 07 Jun 2023 18:14:15 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -881,12 +882,168 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5fe77-10f0-4e2b-81d8-a10c154a44b7
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:17 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:21 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:26 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:13:26.768338Z","members":[{"created_at":"2023-06-07T18:13:26.768338Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:13:26.768338Z","weight":100}],"name":"go-test-lb-backend-1686161606","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:13:26.768338Z"}],"configured_status":"started","created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:47:59Z","name":"go-test-lb-nl-ams1-1686161606","network_uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914","networks":[{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:13:26.574898Z"},{"created_at":"2023-06-07T18:13:26.574898Z","dns_name":"lb-0a8496c8604a48c9a213a97d0753539f-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:13:26.574898Z","uuid":"03bcd448-8480-47a7-a1b9-f155e9e0c914"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:13:46.134852Z","uuid":"0a8496c8-604a-48c9-a213-a97d0753539f","zone":"nl-ams1"}'
+    headers:
+      Content-Length:
+      - "1718"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:14:28 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a8496c8-604a-48c9-a213-a97d0753539f
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZWSW62N9DRJ5WP0SQ7XR6F4","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BH2G2THTZCNY7ZJ33MFZS2","status":404}
     headers:
       Content-Language:
       - en
@@ -895,7 +1052,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Tue, 05 Apr 2022 12:06:02 GMT
+      - Wed, 07 Jun 2023 18:14:30 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -910,14 +1067,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/network/03dc285d-4517-4ffe-922e-593b02fa5196
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03bcd448-8480-47a7-a1b9-f155e9e0c914
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 12:06:02 GMT
+      - Wed, 07 Jun 2023 18:14:30 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/loadbalancercerticatebundlesandfrontendtlsconfigs.yaml
+++ b/upcloud/service/fixtures/loadbalancercerticatebundlesandfrontendtlsconfigs.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1649155917","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"10.0.1.1/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686162573","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"10.0.4.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -20,27 +20,28 @@ interactions:
             "ip_networks" : {
                "ip_network" : [
                   {
-                     "address" : "10.0.1.1/24",
+                     "address" : "10.0.4.0/24",
                      "dhcp" : "yes",
                      "dhcp_default_route" : "no",
                      "family" : "IPv4",
-                     "gateway" : "10.0.1.1"
+                     "gateway" : "10.0.4.1"
                   }
                ]
             },
-            "name" : "go-test-lb-1649155917",
+            "labels" : [],
+            "name" : "go-test-lb-1686162573",
             "type" : "private",
-            "uuid" : "0344a1a9-8878-4a2c-8470-3175e3eae6f6",
+            "uuid" : "0383082a-e6a4-4814-8e8b-b847dabedc23",
             "zone" : "fi-hel1"
          }
       }
     headers:
       Content-Length:
-      - "459"
+      - "480"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 05 Apr 2022 10:51:57 GMT
+      - Wed, 07 Jun 2023 18:29:33 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel1-1649155918","plan":"development","zone":"fi-hel1","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","configured_status":"started","frontends":[{"name":"fe-1","mode":"http","port":80,"default_backend":"be-1"}],"backends":[{"name":"be-1","resolver":"ns-1","members":[]}],"resolvers":[{"name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"cache_valid":10,"cache_invalid":10}]}'
+    body: '{"name":"go-test-lb-fi-hel1-1686162575","plan":"development","zone":"fi-hel1","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","configured_status":"started","frontends":[{"name":"fe-1","mode":"http","port":80,"default_backend":"be-1"}],"backends":[{"name":"be-1","resolver":"ns-1","members":[]}],"resolvers":[{"name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"cache_valid":10,"cache_invalid":10}]}'
     form: {}
     headers:
       Accept:
@@ -57,18 +58,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:51:58.939242Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1044"
+      - "1884"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:58 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -83,16 +84,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles
     method: POST
   response:
-    body: '{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2022-04-05T10:51:59.031748Z","hostnames":[""],"key_type":"rsa","name":"example-manual-certificate","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2022-04-05T10:51:59.031748Z","uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb"}'
+    body: '{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2023-06-07T18:29:35.361475Z","hostnames":[""],"key_type":"rsa","labels":[],"name":"example-manual-certificate","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","services":[],"type":"manual","updated_at":"2023-06-07T18:29:35.361475Z","uuid":"0af8a018-131a-4d4c-831b-e66ed1205900"}'
     headers:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -107,18 +108,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles
     method: POST
   response:
-    body: '{"created_at":"2022-04-05T10:51:59.086986Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","name":"example-dynamic-certificate","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","type":"dynamic","updated_at":"2022-04-05T10:51:59.086986Z","uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02"}'
+    body: '{"created_at":"2023-06-07T18:29:35.493122Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","labels":[],"name":"example-dynamic-certificate","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","services":[],"type":"dynamic","updated_at":"2023-06-07T18:29:35.493122Z","uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1"}'
     headers:
       Content-Length:
-      - "348"
+      - "374"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -133,16 +134,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0af8a018-131a-4d4c-831b-e66ed1205900
     method: PATCH
   response:
-    body: '{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2022-04-05T10:51:59.031748Z","hostnames":[""],"key_type":"rsa","name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2022-04-05T10:51:59.163749Z","uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb"}'
+    body: '{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2023-06-07T18:29:35.361475Z","hostnames":[""],"key_type":"rsa","labels":[],"name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","services":[],"type":"manual","updated_at":"2023-06-07T18:29:35.619125Z","uuid":"0af8a018-131a-4d4c-831b-e66ed1205900"}'
     headers:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -157,18 +158,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0ab4333a-0226-40c0-8012-07fcb6503c02
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1
     method: PATCH
   response:
-    body: '{"created_at":"2022-04-05T10:51:59.086986Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","type":"dynamic","updated_at":"2022-04-05T10:51:59.224305Z","uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02"}'
+    body: '{"created_at":"2023-06-07T18:29:35.493122Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","labels":[],"name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","services":[],"type":"dynamic","updated_at":"2023-06-07T18:29:35.762382Z","uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1"}'
     headers:
       Content-Length:
-      - "353"
+      - "379"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -183,16 +184,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles?limit=100&offset=0
     method: GET
   response:
-    body: '[{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2022-04-05T10:51:59.031748Z","hostnames":[""],"key_type":"rsa","name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2022-04-05T10:51:59.163749Z","uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb"},{"created_at":"2022-04-05T10:51:59.086986Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","type":"dynamic","updated_at":"2022-04-05T10:51:59.224305Z","uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02"}]'
+    body: '[{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2023-06-07T18:29:35.361475Z","hostnames":[""],"key_type":"rsa","labels":[],"name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2023-06-07T18:29:35.619125Z","uuid":"0af8a018-131a-4d4c-831b-e66ed1205900"},{"created_at":"2023-06-07T18:29:35.493122Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","labels":[],"name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","type":"dynamic","updated_at":"2023-06-07T18:29:35.762382Z","uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1"}]'
     headers:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -207,16 +208,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles?limit=1&offset=0
     method: GET
   response:
-    body: '[{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2022-04-05T10:51:59.031748Z","hostnames":[""],"key_type":"rsa","name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2022-04-05T10:51:59.163749Z","uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb"}]'
+    body: '[{"certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lVRzR1KzRDZmlHQ3pQSDk4dDA4QXh5VkE0QzVnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1JURUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeElUQWZCZ05WQkFvTQpHRWx1ZEdWeWJtVjBJRmRwWkdkcGRITWdVSFI1SUV4MFpEQWVGdzB5TWpBek1UY3hNekUxTURoYUZ3MHlNekF6Ck1UY3hNekUxTURoYU1FVXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXcKSHdZRFZRUUtEQmhKYm5SbGNtNWxkQ0JYYVdSbmFYUnpJRkIwZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQgpBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHZaeG4vK3pUeVc0RVJ2S2t3V29tVXBpOG8ydEp6MWR2ZXIrREpySzNnCkNObFVvWXpSMjlDV3M3aks4MVhNc3ZtcUw1TXpUd1A3SHNtZDFxNjlGSStXY1BFMWFhYjk5MDlJQWsvR0dpSzIKelRsZU4zRVFRcFhuN3RueVB0WmFUOFkxM3lGSHBDNVJnUXpURThDUjlaaTJPTEV5eEdRMzZwQTYxOTBueFZnMgpTTGxhZk5HVFp0SnZOMS83cjltSmhFbGJyVUUram9lWEx3Tm9qSC9uWGs1Vy9Yd3paYm9JSHNTRlZZaksyemxnCm9xQzYrQXBvOXhGOW9ZN25sQWhRMEtLV3ZRVmJ3akdQbVZOMTdFVG9kSHNLSlpCb1h4RHNaVVRHQ0RESkNpbXoKVzY0YTc5bFdJeGl5T1E0LzdUbjJGaFBZMG9tSDVVYldDUHEyTW5YZWJrT2pnY3ZVWTROSXd6cFlWMFcyR0dHRwp3d25pOWZsbFlBTTlPRDNidlBYNU9hQVdOSlQ2cjZFYXNzaldsdjBUZUd4RStCWlorZzN4UHFIVEd6MndIekM1CjVhbkxEak0rNHZzQlZrZmtWM1NZN1c4M203NFZRK1FhM1dhTlh6aW5MMGtlRnh1cExYWThiS2hFelh6U0xLeisKQnI4UEdlR1JnYVNEZDFrcEZQZyt1ak44cXZnbzBSREk4SXFMUzd6YlhGb1FycDF4L2RXbTlTOERWRVhWb1VBMQpXUW5WdVdFQ29CUzRaZjQxZDA0cGZkQ3R0bk45ekhvc2d3WGJKOG0wVGZ2Zmt1aFZpdVZBTi9wK01wOVduUStICjExSEVuV3BTZk9oN1pQalR6anVBc2V2VmZWNGc0YTNrY3pNdjFycE5QelVVUHd0QXF4OTIzOXd3SVI5WTE1Y2wKT1FJREFRQUJvMU13VVRBZEJnTlZIUTRFRmdRVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dId1lEVlIwagpCQmd3Rm9BVVhJcWxiajV1TVVGVC9qcU0ya1d2WVp0RE5rY3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBQ00reGJiOW9rVUdPcWtRWmtndHh3eVF0em90WFRXNnlIYmdmeGhCd3d1disKc0ltT1QyOUw5WFVZblM5cTgrQktBSHVGa3JTRUlwR0ZVVWhDVWZTa2xlNmZuR0c1b05PWm1DdEszN3RoZlFVOQp2NEJvOHFCWkhqREh3azlWVHRhWm1BazBLYnhmaHVneVdWQ1ZsbURacm9TQ09pV0drVFZoc1hhS0RrYnc0RWwwCjJzY3lnYkFDdFZ4bkU1WjlmU0F3MU9QWXJZYUcySW5HTDQvMHVSZXo4aXl1UE9lNUNiL0RkNDl1eHFzR1FkM1IKQzdKNC9vWnB2b0V6UVJtakxib1FzQzkwU2ZqaFNpcGhHQlNiYUpCZGRsMDBrNVZzVXJxS1haU004cVFxVWZWLwpubEJtYjJOblVsa2RlOEtIczBQamhCaG8rLzdmaitMN21GYTJsNWpmdWlsdHVxdmgyWnladFJjd2didmJlaUxPCmZQSWlMQ2dTbnMwaitZMkVrS1drRUp6RXJQVm5sOTdaQktZclBaYmRYMFY5b2dvTC9qeEV5NzlsbzlKczI5djYKUkY2NmdvSlUwMkVKZTUwMmk3WHJzMzFZQ0tuSGd2ejUwTDZha0JpYWRSNmtrTXVXdkJ1d1l6MElaS1RMcXhqZAowOEdlUkJVeWFsUFZodGZKbzNNdXRuYUllL1pWVTdLQUl3S1Znb20zS09EY1RpWllQV3RWKzFnL0UvN3A1aGh2CkJERzFqcklRc1ZrZG4yNWZhNXNkNU9Qa1AvbDBRdXY1em16UEk3S1MrS2ZlWS92NHFBOTBtNGk2dkZORlRtbTAKSFNXV0JZTlR4blIxYjk2UElUcnRzOE15am9YTFg2QnUxVkZOSlByMkpnMDJMVlZvcTZSSWJlMVVvNjE5b2pBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","created_at":"2023-06-07T18:29:35.361475Z","hostnames":[""],"key_type":"rsa","labels":[],"name":"example-manual-certificate-edit","not_after":"2023-03-17T13:15:08Z","not_before":"2022-03-17T13:15:08Z","operational_state":"idle","type":"manual","updated_at":"2023-06-07T18:29:35.619125Z","uuid":"0af8a018-131a-4d4c-831b-e66ed1205900"}]'
     headers:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -231,25 +232,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0ab4333a-0226-40c0-8012-07fcb6503c02
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1
     method: GET
   response:
-    body: '{"created_at":"2022-04-05T10:51:59.086986Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","type":"dynamic","updated_at":"2022-04-05T10:51:59.224305Z","uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02"}'
+    body: '{"created_at":"2023-06-07T18:29:35.493122Z","hostnames":["example.com","app.example.com"],"key_type":"rsa","labels":[],"name":"example-dynamic-certificate-edit","not_after":"0001-01-01T00:00:00Z","not_before":"0001-01-01T00:00:00Z","operational_state":"idle","services":[],"type":"dynamic","updated_at":"2023-06-07T18:29:35.762382Z","uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1"}'
     headers:
       Content-Length:
-      - "353"
+      - "379"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"example-manual-certificate-edit","certificate_bundle_uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb"}'
+    body: '{"name":"example-manual-certificate-edit","certificate_bundle_uuid":"0af8a018-131a-4d4c-831b-e66ed1205900"}'
     form: {}
     headers:
       Accept:
@@ -257,25 +258,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f/frontends/fe-1/tls-configs
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335/frontends/fe-1/tls-configs
     method: POST
   response:
-    body: '{"certificate_bundle_uuid":"0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb","created_at":"2022-04-05T10:51:59.452551Z","name":"example-manual-certificate-edit","updated_at":"2022-04-05T10:51:59.452551Z"}'
+    body: '{"certificate_bundle_uuid":"0af8a018-131a-4d4c-831b-e66ed1205900","created_at":"2023-06-07T18:29:36.258779Z","name":"example-manual-certificate-edit","updated_at":"2023-06-07T18:29:36.258779Z"}'
     headers:
       Content-Length:
       - "193"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"example-dynamic-certificate-edit","certificate_bundle_uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02"}'
+    body: '{"name":"example-dynamic-certificate-edit","certificate_bundle_uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1"}'
     form: {}
     headers:
       Accept:
@@ -283,18 +284,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f/frontends/fe-1/tls-configs/example-manual-certificate-edit
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335/frontends/fe-1/tls-configs/example-manual-certificate-edit
     method: PATCH
   response:
-    body: '{"certificate_bundle_uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02","created_at":"2022-04-05T10:51:59.452551Z","name":"example-dynamic-certificate-edit","updated_at":"2022-04-05T10:51:59.539795Z"}'
+    body: '{"certificate_bundle_uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1","created_at":"2023-06-07T18:29:36.258779Z","name":"example-dynamic-certificate-edit","updated_at":"2023-06-07T18:29:36.421572Z"}'
     headers:
       Content-Length:
       - "194"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -309,18 +310,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f/frontends/fe-1/tls-configs
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335/frontends/fe-1/tls-configs
     method: GET
   response:
-    body: '[{"certificate_bundle_uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02","created_at":"2022-04-05T10:51:59.452551Z","name":"example-dynamic-certificate-edit","updated_at":"2022-04-05T10:51:59.539795Z"}]'
+    body: '[{"certificate_bundle_uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1","created_at":"2023-06-07T18:29:36.258779Z","name":"example-dynamic-certificate-edit","updated_at":"2023-06-07T18:29:36.421572Z"}]'
     headers:
       Content-Length:
       - "196"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -335,18 +336,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f/frontends/fe-1/tls-configs/example-dynamic-certificate-edit
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335/frontends/fe-1/tls-configs/example-dynamic-certificate-edit
     method: GET
   response:
-    body: '{"certificate_bundle_uuid":"0ab4333a-0226-40c0-8012-07fcb6503c02","created_at":"2022-04-05T10:51:59.452551Z","name":"example-dynamic-certificate-edit","updated_at":"2022-04-05T10:51:59.539795Z"}'
+    body: '{"certificate_bundle_uuid":"0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1","created_at":"2023-06-07T18:29:36.258779Z","name":"example-dynamic-certificate-edit","updated_at":"2023-06-07T18:29:36.421572Z"}'
     headers:
       Content-Length:
       - "194"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -361,14 +362,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f/frontends/fe-1/tls-configs/example-dynamic-certificate-edit
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335/frontends/fe-1/tls-configs/example-dynamic-certificate-edit
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -383,14 +384,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0ab73b97-a8e9-4dcb-a7a6-1fafbbe503cb
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0af8a018-131a-4d4c-831b-e66ed1205900
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -405,14 +406,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0ab4333a-0226-40c0-8012-07fcb6503c02
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/certificate-bundles/0a8f3ee7-8947-4fbe-bf1d-0cd60c8004e1
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -427,14 +428,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -449,18 +450,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:51:59.930788Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:37.167033Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1044"
+      - "1929"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:51:59 GMT
+      - Wed, 07 Jun 2023 18:29:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -475,18 +476,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:51:59.930788Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:37.167033Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1044"
+      - "1929"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:02 GMT
+      - Wed, 07 Jun 2023 18:29:39 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -501,18 +502,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:51:59.930788Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:37.167033Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1044"
+      - "1929"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:04 GMT
+      - Wed, 07 Jun 2023 18:29:41 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -527,18 +528,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:37.167033Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1929"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:06 GMT
+      - Wed, 07 Jun 2023 18:29:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -553,18 +554,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:37.167033Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1929"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:08 GMT
+      - Wed, 07 Jun 2023 18:29:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -579,18 +580,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:10 GMT
+      - Wed, 07 Jun 2023 18:29:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -605,18 +606,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:12 GMT
+      - Wed, 07 Jun 2023 18:29:50 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -631,18 +632,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:14 GMT
+      - Wed, 07 Jun 2023 18:29:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -657,18 +658,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:16 GMT
+      - Wed, 07 Jun 2023 18:29:54 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -683,18 +684,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:18 GMT
+      - Wed, 07 Jun 2023 18:29:56 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -709,18 +710,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:20 GMT
+      - Wed, 07 Jun 2023 18:29:58 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -735,18 +736,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:22 GMT
+      - Wed, 07 Jun 2023 18:30:00 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -761,18 +762,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:24 GMT
+      - Wed, 07 Jun 2023 18:30:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -787,18 +788,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:26 GMT
+      - Wed, 07 Jun 2023 18:30:04 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -813,18 +814,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-dns","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:29:47.547649Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:28 GMT
+      - Wed, 07 Jun 2023 18:30:07 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -839,18 +840,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:30 GMT
+      - Wed, 07 Jun 2023 18:30:09 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -865,18 +866,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:32 GMT
+      - Wed, 07 Jun 2023 18:30:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -891,18 +892,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:34 GMT
+      - Wed, 07 Jun 2023 18:30:13 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -917,18 +918,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:36 GMT
+      - Wed, 07 Jun 2023 18:30:15 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -943,18 +944,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:39 GMT
+      - Wed, 07 Jun 2023 18:30:17 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -969,18 +970,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:41 GMT
+      - Wed, 07 Jun 2023 18:30:19 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -995,18 +996,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:43 GMT
+      - Wed, 07 Jun 2023 18:30:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1021,18 +1022,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-04-05T10:51:58.939242Z","members":[],"name":"be-1","properties":{"timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2022-04-05T10:51:58.939242Z"}],"configured_status":"started","created_at":"2022-04-05T10:51:58.939242Z","dns_name":"lb-0af5b4cdb0784e1bac5cfa72423d668f.upcloudlb.com","frontends":[{"created_at":"2022-04-05T10:51:58.939242Z","default_backend":"be-1","mode":"http","name":"fe-1","port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-04-05T10:51:58.939242Z"}],"name":"go-test-lb-fi-hel1-1649155918","network_uuid":"0344a1a9-8878-4a2c-8470-3175e3eae6f6","operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2022-04-05T10:51:58.939242Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2022-04-05T10:51:58.939242Z"}],"updated_at":"2022-04-05T10:52:04.970642Z","uuid":"0af5b4cd-b078-4e1b-ac5c-fa72423d668f","zone":"fi-hel1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "1050"
+      - "1935"
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Apr 2022 10:52:45 GMT
+      - Wed, 07 Jun 2023 18:30:24 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1047,12 +1048,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af5b4cd-b078-4e1b-ac5c-fa72423d668f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1935"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:30:26 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1935"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:30:28 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:29:35.217256Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:29:35.217256Z"}],"configured_status":"started","created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:29:35.217256Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:29:35.217256Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"01:03:31Z","name":"go-test-lb-fi-hel1-1686162575","network_uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23","networks":[{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:29:35.217256Z"},{"created_at":"2023-06-07T18:29:35.217256Z","dns_name":"lb-0a191e7bab6c4be6924c20c639ce7335-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:29:35.217256Z","uuid":"0383082a-e6a4-4814-8e8b-b847dabedc23"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:29:35.217256Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:29:35.217256Z"}],"updated_at":"2023-06-07T18:30:07.840662Z","uuid":"0a191e7b-ab6c-4be6-924c-20c639ce7335","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1935"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:30:30 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a191e7b-ab6c-4be6-924c-20c639ce7335
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZWNP27R119PS1HQPXDSYRNB","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BHZVYH3VCADCP898WGFH7Z","status":404}
     headers:
       Content-Language:
       - en
@@ -1061,7 +1140,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Tue, 05 Apr 2022 10:52:47 GMT
+      - Wed, 07 Jun 2023 18:30:32 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1076,14 +1155,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/network/0344a1a9-8878-4a2c-8470-3175e3eae6f6
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/0383082a-e6a4-4814-8e8b-b847dabedc23
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Tue, 05 Apr 2022 10:52:47 GMT
+      - Wed, 07 Jun 2023 18:30:32 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/loadbalancerfrontend.yaml
+++ b/upcloud/service/fixtures/loadbalancerfrontend.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1654851663","zone":"de-fra1","ip_networks":{"ip_network":[{"address":"10.0.0.1/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686161989","zone":"de-fra1","ip_networks":{"ip_network":[{"address":"10.0.3.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -20,27 +20,28 @@ interactions:
             "ip_networks" : {
                "ip_network" : [
                   {
-                     "address" : "10.0.0.1/24",
+                     "address" : "10.0.3.0/24",
                      "dhcp" : "yes",
                      "dhcp_default_route" : "no",
                      "family" : "IPv4",
-                     "gateway" : "10.0.0.1"
+                     "gateway" : "10.0.3.1"
                   }
                ]
             },
-            "name" : "go-test-lb-1654851663",
+            "labels" : [],
+            "name" : "go-test-lb-1686161989",
             "type" : "private",
-            "uuid" : "0328a429-0270-477a-9c11-411369718090",
+            "uuid" : "03e11e32-af22-420e-91ef-ebfb248daa6f",
             "zone" : "de-fra1"
          }
       }
     headers:
       Content-Length:
-      - "459"
+      - "480"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 10 Jun 2022 09:01:03 GMT
+      - Wed, 07 Jun 2023 18:19:49 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-de-fra1-1654851664","plan":"development","zone":"de-fra1","network_uuid":"0328a429-0270-477a-9c11-411369718090","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-de-fra1-1686161990","plan":"development","zone":"de-fra1","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,25 +58,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:04.475777Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:51.13509Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "431"
+      - "983"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-backend-1654851664","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}]}'
+    body: '{"name":"go-test-lb-backend-1686161991","members":[{"name":"default-lb-backend-member","weight":100,"max_sessions":1000,"enabled":true,"type":"dynamic","ip":"196.123.123.123","port":8000}],"properties":{"timeout_server":30}}'
     form: {}
     headers:
       Accept:
@@ -83,25 +84,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/backends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/backends
     method: POST
   response:
-    body: '{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}'
+    body: '{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}'
     headers:
       Content-Length:
-      - "605"
+      - "680"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"fe-1","mode":"http","port":443,"default_backend":"go-test-lb-backend-1654851664","properties":{"timeout_client":10,"inbound_proxy_protocol":false}}'
+    body: '{"name":"fe-1","mode":"http","port":443,"default_backend":"go-test-lb-backend-1686161991","properties":{"timeout_client":10,"inbound_proxy_protocol":false}}'
     form: {}
     headers:
       Accept:
@@ -109,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/frontends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/frontends
     method: POST
   response:
-    body: '{"created_at":"2022-06-10T09:01:04.622599Z","default_backend":"go-test-lb-backend-1654851664","mode":"http","name":"fe-1","port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-06-10T09:01:04.622599Z"}'
+    body: '{"created_at":"2023-06-07T18:19:51.466745Z","default_backend":"go-test-lb-backend-1686161991","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:19:51.466745Z"}'
     headers:
       Content-Length:
-      - "239"
+      - "275"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -135,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/frontends/fe-1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/frontends/fe-1
     method: PATCH
   response:
-    body: '{"created_at":"2022-06-10T09:01:04.622599Z","default_backend":"go-test-lb-backend-1654851664","mode":"tcp","name":"fe-2","port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-06-10T09:01:04.693501Z"}'
+    body: '{"created_at":"2023-06-07T18:19:51.466745Z","default_backend":"go-test-lb-backend-1686161991","mode":"tcp","name":"fe-2","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:19:51.626563Z"}'
     headers:
       Content-Length:
-      - "267"
+      - "303"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -161,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/frontends/fe-2
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/frontends/fe-2
     method: GET
   response:
-    body: '{"created_at":"2022-06-10T09:01:04.622599Z","default_backend":"go-test-lb-backend-1654851664","mode":"tcp","name":"fe-2","port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-06-10T09:01:04.693501Z"}'
+    body: '{"created_at":"2023-06-07T18:19:51.466745Z","default_backend":"go-test-lb-backend-1686161991","mode":"tcp","name":"fe-2","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:19:51.626563Z"}'
     headers:
       Content-Length:
-      - "267"
+      - "303"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -187,18 +188,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/frontends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/frontends
     method: GET
   response:
-    body: '[{"created_at":"2022-06-10T09:01:04.622599Z","default_backend":"go-test-lb-backend-1654851664","mode":"tcp","name":"fe-2","port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-06-10T09:01:04.693501Z"}]'
+    body: '[{"created_at":"2023-06-07T18:19:51.466745Z","default_backend":"go-test-lb-backend-1686161991","mode":"tcp","name":"fe-2","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"inbound_proxy_protocol":true,"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:19:51.626563Z"}]'
     headers:
       Content-Length:
-      - "269"
+      - "305"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -213,14 +214,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab/frontends/fe-2
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073/frontends/fe-2
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -235,14 +236,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -257,18 +258,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:04.911032Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1036"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:04 GMT
+      - Wed, 07 Jun 2023 18:19:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -283,18 +284,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:04.911032Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1036"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:07 GMT
+      - Wed, 07 Jun 2023 18:19:54 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -309,18 +310,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:04.911032Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1036"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:09 GMT
+      - Wed, 07 Jun 2023 18:19:56 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -335,18 +336,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:11 GMT
+      - Wed, 07 Jun 2023 18:19:58 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -361,18 +362,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:13 GMT
+      - Wed, 07 Jun 2023 18:20:00 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -387,18 +388,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:15 GMT
+      - Wed, 07 Jun 2023 18:20:03 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -413,18 +414,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:17 GMT
+      - Wed, 07 Jun 2023 18:20:05 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -439,18 +440,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:19 GMT
+      - Wed, 07 Jun 2023 18:20:07 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -465,18 +466,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:21 GMT
+      - Wed, 07 Jun 2023 18:20:09 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -491,18 +492,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:23 GMT
+      - Wed, 07 Jun 2023 18:20:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -517,18 +518,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:25 GMT
+      - Wed, 07 Jun 2023 18:20:13 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -543,18 +544,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:19:52.207797Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1709"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:27 GMT
+      - Wed, 07 Jun 2023 18:20:15 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -569,18 +570,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:29 GMT
+      - Wed, 07 Jun 2023 18:20:17 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -595,18 +596,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:31 GMT
+      - Wed, 07 Jun 2023 18:20:20 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -621,18 +622,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:33 GMT
+      - Wed, 07 Jun 2023 18:20:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -647,18 +648,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:35 GMT
+      - Wed, 07 Jun 2023 18:20:24 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -673,18 +674,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:37 GMT
+      - Wed, 07 Jun 2023 18:20:26 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -699,18 +700,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:39 GMT
+      - Wed, 07 Jun 2023 18:20:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -725,18 +726,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:41 GMT
+      - Wed, 07 Jun 2023 18:20:30 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -751,18 +752,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:43 GMT
+      - Wed, 07 Jun 2023 18:20:32 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -777,18 +778,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:46 GMT
+      - Wed, 07 Jun 2023 18:20:34 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -803,18 +804,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:48 GMT
+      - Wed, 07 Jun 2023 18:20:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -829,18 +830,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:50 GMT
+      - Wed, 07 Jun 2023 18:20:39 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -855,18 +856,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:52 GMT
+      - Wed, 07 Jun 2023 18:20:41 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -881,18 +882,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:54 GMT
+      - Wed, 07 Jun 2023 18:20:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -907,18 +908,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:56 GMT
+      - Wed, 07 Jun 2023 18:20:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -933,18 +934,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:01:58 GMT
+      - Wed, 07 Jun 2023 18:20:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -959,18 +960,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-06-10T09:01:04.551274Z","members":[{"created_at":"2022-06-10T09:01:04.551274Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2022-06-10T09:01:04.551274Z","weight":100}],"name":"go-test-lb-backend-1654851664","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-06-10T09:01:04.551274Z"}],"configured_status":"started","created_at":"2022-06-10T09:01:04.475777Z","dns_name":"lb-0ae8d7a3a289443c8bc63b68375052ab.upcloudlb.com","frontends":[],"name":"go-test-lb-de-fra1-1654851664","network_uuid":"0328a429-0270-477a-9c11-411369718090","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-06-10T09:01:09.952824Z","uuid":"0ae8d7a3-a289-443c-8bc6-3b68375052ab","zone":"de-fra1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
     headers:
       Content-Length:
-      - "1042"
+      - "1715"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Jun 2022 09:02:00 GMT
+      - Wed, 07 Jun 2023 18:20:49 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -985,12 +986,350 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/load-balancer/0ae8d7a3-a289-443c-8bc6-3b68375052ab
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:20:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:20:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:20:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:20:58 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:00 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:06 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:09 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:11 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:13 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:15 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:19:51.319069Z","members":[{"created_at":"2023-06-07T18:19:51.319069Z","enabled":true,"ip":"196.123.123.123","max_sessions":1000,"name":"default-lb-backend-member","port":8000,"type":"dynamic","updated_at":"2023-06-07T18:19:51.319069Z","weight":100}],"name":"go-test-lb-backend-1686161991","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":30,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:19:51.319069Z"}],"configured_status":"started","created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:54:28Z","name":"go-test-lb-de-fra1-1686161990","network_uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f","networks":[{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:19:51.13509Z"},{"created_at":"2023-06-07T18:19:51.13509Z","dns_name":"lb-0a630741321e4652ae4507dda730c073-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:19:51.13509Z","uuid":"03e11e32-af22-420e-91ef-ebfb248daa6f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:20:17.680598Z","uuid":"0a630741-321e-4652-ae45-07dda730c073","zone":"de-fra1"}'
+    headers:
+      Content-Length:
+      - "1715"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:21:17 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a630741-321e-4652-ae45-07dda730c073
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01G56DJQ6EETKHBSQFPJ2X4EZN","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BHEZYSMPF4AVE6YH3G5MVV","status":404}
     headers:
       Content-Language:
       - en
@@ -999,7 +1338,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 10 Jun 2022 09:02:02 GMT
+      - Wed, 07 Jun 2023 18:21:19 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1014,14 +1353,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.6.0
-    url: https://api.upcloud.com/1.3/network/0328a429-0270-477a-9c11-411369718090
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03e11e32-af22-420e-91ef-ebfb248daa6f
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 10 Jun 2022 09:02:02 GMT
+      - Wed, 07 Jun 2023 18:21:19 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/loadbalancerfrontendrule.yaml
+++ b/upcloud/service/fixtures/loadbalancerfrontendrule.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1685686735","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"10.0.1.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686162462","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"10.0.1.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -29,9 +29,9 @@ interactions:
                ]
             },
             "labels" : [],
-            "name" : "go-test-lb-1685686735",
+            "name" : "go-test-lb-1686162462",
             "type" : "private",
-            "uuid" : "031440be-dda9-4585-9968-aa53d460cb8d",
+            "uuid" : "038267fb-505d-4b12-aa24-00351611ab64",
             "zone" : "fi-hel2"
          }
       }
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 02 Jun 2023 06:18:55 GMT
+      - Wed, 07 Jun 2023 18:27:42 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -50,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1685686737","plan":"development","zone":"fi-hel2","network_uuid":"031440be-dda9-4585-9968-aa53d460cb8d","configured_status":"started","frontends":[{"name":"fe-1","mode":"http","port":80,"default_backend":"be-1"}],"backends":[{"name":"be-1","resolver":"ns-1","members":[]}],"resolvers":[{"name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"cache_valid":10,"cache_invalid":10}]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162463","plan":"development","zone":"fi-hel2","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","configured_status":"started","frontends":[{"name":"fe-1","mode":"http","port":80,"default_backend":"be-1"}],"backends":[{"name":"be-1","resolver":"ns-1","members":[]}],"resolvers":[{"name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"cache_valid":10,"cache_invalid":10}]}'
     form: {}
     headers:
       Accept:
@@ -58,18 +58,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[{"created_at":"2023-06-02T06:18:57.41458Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-02T06:18:57.41458Z"}],"configured_status":"started","created_at":"2023-06-02T06:18:57.41458Z","dns_name":"lb-0a0ad2776ff64980ab41cd6b2b1ed8e9-1.upcloudlb.com","frontends":[{"created_at":"2023-06-02T06:18:57.41458Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-02T06:18:57.41458Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"02:12:55Z","name":"go-test-lb-fi-hel2-1685686737","network_uuid":"031440be-dda9-4585-9968-aa53d460cb8d","networks":[{"created_at":"2023-06-02T06:18:57.41458Z","dns_name":"lb-0a0ad2776ff64980ab41cd6b2b1ed8e9-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-02T06:18:57.41458Z"},{"created_at":"2023-06-02T06:18:57.41458Z","dns_name":"lb-0a0ad2776ff64980ab41cd6b2b1ed8e9-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-02T06:18:57.41458Z","uuid":"031440be-dda9-4585-9968-aa53d460cb8d"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-02T06:18:57.41458Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-02T06:18:57.41458Z"}],"updated_at":"2023-06-02T06:18:57.41458Z","uuid":"0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9","zone":"fi-hel2"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:43.857693Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "1842"
+      - "1884"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -84,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules
     method: POST
   response:
-    body: '{"actions":[{"type":"tcp_reject","action_tcp_reject":{}}],"created_at":"2023-06-02T06:18:57.521785Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.200"}},{"type":"src_ip","inverse":true,"match_src_ip":{"value":"10.1.2.200"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-02T06:18:57.521785Z"}'
+    body: '{"actions":[{"type":"tcp_reject","action_tcp_reject":{}}],"created_at":"2023-06-07T18:27:44.040296Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.200"}},{"type":"src_ip","inverse":true,"match_src_ip":{"value":"10.1.2.200"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-07T18:27:44.040296Z"}'
     headers:
       Content-Length:
       - "330"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -110,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules/rule-1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules/rule-1
     method: PATCH
   response:
-    body: '{"actions":[{"type":"tcp_reject","action_tcp_reject":{}}],"created_at":"2023-06-02T06:18:57.521785Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.200"}},{"type":"src_ip","inverse":true,"match_src_ip":{"value":"10.1.2.200"}}],"name":"rule","priority":20,"updated_at":"2023-06-02T06:18:57.598608Z"}'
+    body: '{"actions":[{"type":"tcp_reject","action_tcp_reject":{}}],"created_at":"2023-06-07T18:27:44.040296Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.200"}},{"type":"src_ip","inverse":true,"match_src_ip":{"value":"10.1.2.200"}}],"name":"rule","priority":20,"updated_at":"2023-06-07T18:27:44.206871Z"}'
     headers:
       Content-Length:
       - "328"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -136,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules/rule
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules/rule
     method: PUT
   response:
-    body: '{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-02T06:18:57.681863Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-02T06:18:57.681863Z"}'
+    body: '{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-07T18:27:44.386791Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-07T18:27:44.386791Z"}'
     headers:
       Content-Length:
       - "337"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -162,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules
     method: GET
   response:
-    body: '[{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-02T06:18:57.681863Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-02T06:18:57.681863Z"}]'
+    body: '[{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-07T18:27:44.386791Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-07T18:27:44.386791Z"}]'
     headers:
       Content-Length:
       - "339"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -188,18 +188,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules/rule-1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules/rule-1
     method: GET
   response:
-    body: '{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-02T06:18:57.681863Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-02T06:18:57.681863Z"}'
+    body: '{"actions":[{"type":"http_return","action_http_return":{"status":404,"content_type":"text/html","payload":"PGgxPmFwcGxlYmVlPC9oMT4K"}}],"created_at":"2023-06-07T18:27:44.386791Z","matchers":[{"type":"src_ip","inverse":false,"match_src_ip":{"value":"10.1.1.201"}}],"name":"rule-1","priority":10,"updated_at":"2023-06-07T18:27:44.386791Z"}'
     headers:
       Content-Length:
       - "337"
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -214,14 +214,1051 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/6.2.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a0ad277-6ff6-4980-ab41-cd6b2b1ed8e9/frontends/fe-1/rules/rule-1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d/frontends/fe-1/rules/rule-1
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 02 Jun 2023 06:18:57 GMT
+      - Wed, 07 Jun 2023 18:27:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:27:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:45.116715Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1929"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:45.116715Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1929"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:45.116715Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1929"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:27:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:10 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:12 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:14 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:16 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:18 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:20 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:27 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:29 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:31 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:33 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:35 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:38 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:40 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:28:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:29:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:27:43.857693Z","members":[],"name":"be-1","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"ns-1","updated_at":"2023-06-07T18:27:43.857693Z"}],"configured_status":"started","created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:27:43.857693Z","default_backend":"be-1","mode":"http","name":"fe-1","networks":[{"name":"public-IPv4"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:27:43.857693Z"}],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:36:24Z","name":"go-test-lb-fi-hel2-1686162463","network_uuid":"038267fb-505d-4b12-aa24-00351611ab64","networks":[{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:27:43.857693Z"},{"created_at":"2023-06-07T18:27:43.857693Z","dns_name":"lb-0af32ff070974d8fa73ae56d03bd726d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:27:43.857693Z","uuid":"038267fb-505d-4b12-aa24-00351611ab64"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[{"cache_invalid":10,"cache_valid":10,"created_at":"2023-06-07T18:27:43.857693Z","name":"ns-1","nameservers":["10.1.1.100"],"retries":10,"timeout":10,"timeout_retry":10,"updated_at":"2023-06-07T18:27:43.857693Z"}],"updated_at":"2023-06-07T18:27:51.32124Z","uuid":"0af32ff0-7097-4d8f-a73a-e56d03bd726d","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1934"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:29:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0af32ff0-7097-4d8f-a73a-e56d03bd726d
+    method: GET
+  response:
+    body: |
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BHX75XG0JZD2J07H86V6X5","status":404}
+    headers:
+      Content-Language:
+      - en
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/problem+json
+      Date:
+      - Wed, 07 Jun 2023 18:29:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/038267fb-505d-4b12-aa24-00351611ab64
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:29:05 GMT
+      Server:
+      - Apache
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content

--- a/upcloud/service/fixtures/loadbalancerlabels.yaml
+++ b/upcloud/service/fixtures/loadbalancerlabels.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1674218941","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.12.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686163040","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.12.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -29,9 +29,9 @@ interactions:
                ]
             },
             "labels" : [],
-            "name" : "go-test-lb-1674218941",
+            "name" : "go-test-lb-1686163040",
             "type" : "private",
-            "uuid" : "03bfce1d-4a26-4d6b-a548-3c61832072b1",
+            "uuid" : "0350d4ac-d377-4a98-8cbe-51267552d714",
             "zone" : "fi-hel2"
          }
       }
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 20 Jan 2023 12:49:01 GMT
+      - Wed, 07 Jun 2023 18:37:20 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -50,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1674218942","plan":"development","zone":"fi-hel2","network_uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1","configured_status":"started","frontends":[],"backends":[],"resolvers":[],"labels":[{"key":"zone","value":"hel2"}]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686163041","plan":"development","zone":"fi-hel2","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","configured_status":"started","frontends":[],"backends":[],"resolvers":[],"labels":[{"key":"zone","value":"hel2"}]}'
     form: {}
     headers:
       Accept:
@@ -58,25 +58,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"name":"go-test-lb-fi-hel2-1674218942","network_uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1","networks":[{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:02.45584Z"},{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:02.45584Z","uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:02.45584Z","uuid":"0ad671d4-0a66-480d-9808-4dbccc7c503d","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "952"
+      - "1016"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:02 GMT
+      - Wed, 07 Jun 2023 18:37:21 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"network":{"name":"go-test-lb-1674218942","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"172.16.14.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686163041","zone":"fi-hel1","ip_networks":{"ip_network":[{"address":"172.16.14.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -84,7 +84,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -103,9 +103,9 @@ interactions:
                ]
             },
             "labels" : [],
-            "name" : "go-test-lb-1674218942",
+            "name" : "go-test-lb-1686163041",
             "type" : "private",
-            "uuid" : "033854bc-a87e-4735-84fa-249fe56ae202",
+            "uuid" : "03e4f0c3-7907-457e-8f02-94a3c1fdabfe",
             "zone" : "fi-hel1"
          }
       }
@@ -115,7 +115,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 20 Jan 2023 12:49:02 GMT
+      - Wed, 07 Jun 2023 18:37:21 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -124,7 +124,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel1-1674218943","plan":"development","zone":"fi-hel1","network_uuid":"033854bc-a87e-4735-84fa-249fe56ae202","configured_status":"started","frontends":[],"backends":[],"resolvers":[],"labels":[{"key":"zone","value":"hel1"}]}'
+    body: '{"name":"go-test-lb-fi-hel1-1686163042","plan":"development","zone":"fi-hel1","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","configured_status":"started","frontends":[],"backends":[],"resolvers":[],"labels":[{"key":"zone","value":"hel1"}]}'
     form: {}
     headers:
       Accept:
@@ -132,18 +132,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"name":"go-test-lb-fi-hel1-1674218943","network_uuid":"033854bc-a87e-4735-84fa-249fe56ae202","networks":[{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:03.283804Z"},{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:03.283804Z","uuid":"033854bc-a87e-4735-84fa-249fe56ae202"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:03.283804Z","uuid":"0a6a2616-64b5-4740-8826-4b53984f7855","zone":"fi-hel1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:22.435383Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
     headers:
       Content-Length:
-      - "958"
+      - "1016"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:03 GMT
+      - Wed, 07 Jun 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -158,18 +158,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?label=zone&limit=100&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"name":"go-test-lb-fi-hel2-1674218942","network_uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1","networks":[{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:02.45584Z"},{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:02.45584Z","uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:02.596572Z","uuid":"0ad671d4-0a66-480d-9808-4dbccc7c503d","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"name":"go-test-lb-fi-hel1-1674218943","network_uuid":"033854bc-a87e-4735-84fa-249fe56ae202","networks":[{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:03.283804Z"},{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:03.283804Z","uuid":"033854bc-a87e-4735-84fa-249fe56ae202"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:03.353884Z","uuid":"0a6a2616-64b5-4740-8826-4b53984f7855","zone":"fi-hel1"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:21.555792Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:22.484959Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}]'
     headers:
-      Content-Length:
-      - "2014"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:03 GMT
+      - Wed, 07 Jun 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -184,18 +182,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?label=zone&limit=1&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"name":"go-test-lb-fi-hel2-1674218942","network_uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1","networks":[{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:02.45584Z"},{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:02.45584Z","uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:02.596572Z","uuid":"0ad671d4-0a66-480d-9808-4dbccc7c503d","zone":"fi-hel2"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel2"}],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:21.555792Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}]'
     headers:
       Content-Length:
-      - "1005"
+      - "1068"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:03 GMT
+      - Wed, 07 Jun 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -210,18 +208,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?label=zone%3Dhel1&limit=100&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"name":"go-test-lb-fi-hel1-1674218943","network_uuid":"033854bc-a87e-4735-84fa-249fe56ae202","networks":[{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:03.283804Z"},{"created_at":"2023-01-20T12:49:03.283804Z","dns_name":"lb-0a6a261664b5474088264b53984f7855-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:03.283804Z","uuid":"033854bc-a87e-4735-84fa-249fe56ae202"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:03.431829Z","uuid":"0a6a2616-64b5-4740-8826-4b53984f7855","zone":"fi-hel1"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:22.644194Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}]'
     headers:
       Content-Length:
-      - "1010"
+      - "1068"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:03 GMT
+      - Wed, 07 Jun 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -236,20 +234,1236 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/5.2.1
-    url: https://api.upcloud.com/1.3/load-balancer/0ad671d4-0a66-480d-9808-4dbccc7c503d
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
     method: PATCH
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","frontends":[],"labels":[],"name":"go-test-lb-fi-hel2-1674218942","network_uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1","networks":[{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-01-20T12:49:02.45584Z"},{"created_at":"2023-01-20T12:49:02.45584Z","dns_name":"lb-0ad671d40a66480d98084dbccc7c503d-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-01-20T12:49:02.45584Z","uuid":"03bfce1d-4a26-4d6b-a548-3c61832072b1"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-01-20T12:49:03.606529Z","uuid":"0ad671d4-0a66-480d-9808-4dbccc7c503d","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:23.056178Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "969"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Jan 2023 12:49:03 GMT
+      - Wed, 07 Jun 2023 18:37:23 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:37:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:23.189436Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1032"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:23.189436Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1032"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:23.189436Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1032"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:27 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:23.189436Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1032"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:29 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:31 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:33 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:36 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:38 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:40 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:08 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:10 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:12 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:14 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:16 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:18 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:20 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:50:16Z","name":"go-test-lb-fi-hel2-1686163041","network_uuid":"0350d4ac-d377-4a98-8cbe-51267552d714","networks":[{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:21.399166Z"},{"created_at":"2023-06-07T18:37:21.399166Z","dns_name":"lb-0a33295bacda4289915d628ba9403eb7-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:21.399166Z","uuid":"0350d4ac-d377-4a98-8cbe-51267552d714"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:37:30.139278Z","uuid":"0a33295b-acda-4289-915d-628ba9403eb7","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:22 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a33295b-acda-4289-915d-628ba9403eb7
+    method: GET
+  response:
+    body: |
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJE96D2N787BAQAG4J9Q78","status":404}
+    headers:
+      Content-Language:
+      - en
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/problem+json
+      Date:
+      - Wed, 07 Jun 2023 18:38:24 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/0350d4ac-d377-4a98-8cbe-51267552d714
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:38:25 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:38:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.306931Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:27 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:29 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:31 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:33 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:36 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:38 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:40 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","frontends":[],"labels":[{"key":"zone","value":"hel1"}],"maintenance_dow":"sunday","maintenance_time":"00:00:12Z","name":"go-test-lb-fi-hel1-1686163042","network_uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe","networks":[{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:37:22.435383Z"},{"created_at":"2023-06-07T18:37:22.435383Z","dns_name":"lb-0a843cc28b2d4875aedd88e03eaebe34-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:37:22.435383Z","uuid":"03e4f0c3-7907-457e-8f02-94a3c1fdabfe"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:38:25.453545Z","uuid":"0a843cc2-8b2d-4875-aedd-88e03eaebe34","zone":"fi-hel1"}'
+    headers:
+      Content-Length:
+      - "1067"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:38:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a843cc2-8b2d-4875-aedd-88e03eaebe34
+    method: GET
+  response:
+    body: |
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJF2EKYHT1GZEHCS9HBSNB","status":404}
+    headers:
+      Content-Language:
+      - en
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/problem+json
+      Date:
+      - Wed, 07 Jun 2023 18:38:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03e4f0c3-7907-457e-8f02-94a3c1fdabfe
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:38:50 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/upcloud/service/fixtures/loadbalancernetworks.yaml
+++ b/upcloud/service/fixtures/loadbalancernetworks.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1667566873","zone":"pl-waw1","ip_networks":{"ip_network":[{"address":"192.168.55.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686162854","zone":"pl-waw1","ip_networks":{"ip_network":[{"address":"192.168.55.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1667566873",
+            "labels" : [],
+            "name" : "go-test-lb-1686162854",
             "type" : "private",
-            "uuid" : "035d4ba8-02d1-452b-8e16-63b3f2a292c3",
+            "uuid" : "03b5e42a-339e-4466-999a-03021a0219e1",
             "zone" : "pl-waw1"
          }
       }
     headers:
       Content-Length:
-      - "467"
+      - "488"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 04 Nov 2022 13:01:13 GMT
+      - Wed, 07 Jun 2023 18:34:14 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-networks-pl-waw1-1667566873","plan":"development","zone":"pl-waw1","networks":[{"name":"public_net","type":"public","family":"IPv4"},{"name":"private_net","type":"private","family":"IPv4","uuid":"035d4ba8-02d1-452b-8e16-63b3f2a292c3"}],"configured_status":"started","frontends":[{"name":"fe1_network_test","mode":"http","port":80,"default_backend":"be_network_test","networks":[{"name":"public_net"},{"name":"private_net"}]}],"backends":[{"name":"be_network_test","members":[]}],"resolvers":[]}'
+    body: '{"name":"go-test-lb-networks-pl-waw1-1686162856","plan":"development","zone":"pl-waw1","networks":[{"name":"public_net","type":"public","family":"IPv4"},{"name":"private_net","type":"private","family":"IPv4","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"configured_status":"started","frontends":[{"name":"fe1_network_test","mode":"http","port":80,"default_backend":"be_network_test","networks":[{"name":"public_net"},{"name":"private_net"}]}],"backends":[{"name":"be_network_test","members":[]}],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,18 +58,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[{"created_at":"2022-11-04T13:01:14.265489Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-11-04T13:01:14.265489Z"}],"configured_status":"started","created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-1.upcloudlb.com","frontends":[{"created_at":"2022-11-04T13:01:14.265489Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-11-04T13:01:14.265489Z"}],"name":"go-test-lb-networks-pl-waw1-1667566873","networks":[{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2022-11-04T13:01:14.265489Z"},{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2022-11-04T13:01:14.265489Z","uuid":"035d4ba8-02d1-452b-8e16-63b3f2a292c3"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-11-04T13:01:14.265489Z","uuid":"0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e","zone":"pl-waw1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:34:16.304532Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:34:16.304532Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "1533"
+      - "1680"
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 13:01:14 GMT
+      - Wed, 07 Jun 2023 18:34:16 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -83,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e/frontends
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f/frontends
     method: POST
   response:
-    body: '{"created_at":"2022-11-04T13:01:14.404417Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-11-04T13:01:14.404417Z"}'
+    body: '{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}'
     headers:
       Content-Length:
       - "273"
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 13:01:14 GMT
+      - Wed, 07 Jun 2023 18:34:16 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -109,16 +110,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
     method: GET
   response:
-    body: '{"backends":[{"created_at":"2022-11-04T13:01:14.265489Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_type":"tcp","health_check_url":"/","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"updated_at":"2022-11-04T13:01:14.265489Z"}],"configured_status":"started","created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-1.upcloudlb.com","frontends":[{"created_at":"2022-11-04T13:01:14.265489Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-11-04T13:01:14.265489Z"},{"created_at":"2022-11-04T13:01:14.404417Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2022-11-04T13:01:14.404417Z"}],"name":"go-test-lb-networks-pl-waw1-1667566873","networks":[{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2022-11-04T13:01:14.265489Z"},{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2022-11-04T13:01:14.265489Z","uuid":"035d4ba8-02d1-452b-8e16-63b3f2a292c3"}],"nodes":[{"networks":[{"ip_addresses":[{"address":"185.70.198.134","listen":true}],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"running","plan":"development","resolvers":[],"updated_at":"2022-11-04T13:03:21.005661Z","uuid":"0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e","zone":"pl-waw1"}'
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:34:16.304532Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[{"address":"5.22.223.127","listen":true}],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"running","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:43.350606Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
     headers:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 13:03:23 GMT
+      - Wed, 07 Jun 2023 18:36:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -133,18 +134,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e/networks/private_net
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f/networks/private_net
     method: PATCH
   response:
-    body: '{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-2.upcloudlb.com","family":"IPv4","name":"internal_net","type":"private","updated_at":"2022-11-04T13:03:23.252855Z","uuid":"035d4ba8-02d1-452b-8e16-63b3f2a292c3"}'
+    body: '{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"internal_net","type":"private","updated_at":"2023-06-07T18:36:44.021991Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}'
     headers:
       Content-Length:
       - "253"
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 13:03:23 GMT
+      - Wed, 07 Jun 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -159,20 +160,359 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a6351d4-6663-42fe-a8ff-8c64dcd4ca6e/networks/internal_net
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f/networks/internal_net
     method: PATCH
   response:
-    body: '{"created_at":"2022-11-04T13:01:14.265489Z","dns_name":"lb-0a6351d4666342fea8ff8c64dcd4ca6e-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2022-11-04T13:03:23.349226Z","uuid":"035d4ba8-02d1-452b-8e16-63b3f2a292c3"}'
+    body: '{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}'
     headers:
       Content-Length:
       - "252"
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 13:03:23 GMT
+      - Wed, 07 Jun 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:36:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[{"address":"5.22.223.127","listen":true}],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-network","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.37756Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:36:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: '{"backends":[{"created_at":"2023-06-07T18:34:16.304532Z","members":[],"name":"be_network_test","properties":{"health_check_expected_status":200,"health_check_fall":3,"health_check_interval":10,"health_check_rise":3,"health_check_tls_verify":false,"health_check_type":"tcp","health_check_url":"/","outbound_proxy_protocol":"","sticky_session_cookie_name":"","timeout_server":10,"timeout_tunnel":3600},"resolver":"","updated_at":"2023-06-07T18:34:16.304532Z"}],"configured_status":"started","created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","frontends":[{"created_at":"2023-06-07T18:34:16.304532Z","default_backend":"be_network_test","mode":"http","name":"fe1_network_test","networks":[{"name":"public_net"},{"name":"private_net"}],"port":80,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.492211Z","default_backend":"be_network_test","mode":"http","name":"fe2_network_test","networks":[{"name":"private_net"}],"port":443,"properties":{"timeout_client":10},"rules":[],"tls_configs":[],"updated_at":"2023-06-07T18:34:16.492211Z"}],"labels":[],"maintenance_dow":"saturday","maintenance_time":"03:03:04Z","name":"go-test-lb-networks-pl-waw1-1686162856","networks":[{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-1.upcloudlb.com","family":"IPv4","name":"public_net","type":"public","updated_at":"2023-06-07T18:34:16.304532Z"},{"created_at":"2023-06-07T18:34:16.304532Z","dns_name":"lb-0a32aa773c9b47938064df52efb7309f-2.upcloudlb.com","family":"IPv4","name":"private_net","type":"private","updated_at":"2023-06-07T18:36:44.161423Z","uuid":"03b5e42a-339e-4466-999a-03021a0219e1"}],"nodes":[{"networks":[{"ip_addresses":[],"name":"public_net","type":"public"},{"ip_addresses":[{"address":"192.168.55.2","listen":false},{"address":"192.168.55.3","listen":true}],"name":"private_net","type":"private"}],"operational_state":"running"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:36:44.901895Z","uuid":"0a32aa77-3c9b-4793-8064-df52efb7309f","zone":"pl-waw1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:37:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a32aa77-3c9b-4793-8064-df52efb7309f
+    method: GET
+  response:
+    body: |
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJBXW1CY7DT5SNKSGFBVR5","status":404}
+    headers:
+      Content-Language:
+      - en
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/problem+json
+      Date:
+      - Wed, 07 Jun 2023 18:37:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03b5e42a-339e-4466-999a-03021a0219e1
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 07 Jun 2023 18:37:07 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/upcloud/service/fixtures/loadbalancerpage.yaml
+++ b/upcloud/service/fixtures/loadbalancerpage.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1648824572","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.0.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686162644","zone":"fi-hel2","ip_networks":{"ip_network":[{"address":"172.16.0.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1648824572",
+            "labels" : [],
+            "name" : "go-test-lb-1686162644",
             "type" : "private",
-            "uuid" : "03dacc38-b334-4fd5-826c-3a351b884770",
+            "uuid" : "036b8041-6759-4820-80a1-0a2471da241f",
             "zone" : "fi-hel2"
          }
       }
     headers:
       Content-Length:
-      - "463"
+      - "484"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 01 Apr 2022 14:49:32 GMT
+      - Wed, 07 Jun 2023 18:30:44 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1648824573","plan":"development","zone":"fi-hel2","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162645","plan":"development","zone":"fi-hel2","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,25 +58,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:33.538326Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:45.625882Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "989"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:33 GMT
+      - Wed, 07 Jun 2023 18:30:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1648824574","plan":"development","zone":"fi-hel2","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162646","plan":"development","zone":"fi-hel2","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -83,25 +84,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:34.600087Z","dns_name":"lb-0af7700eb82e40e3baafbc0870730ee1.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824574","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:34.600087Z","uuid":"0af7700e-b82e-40e3-baaf-bc0870730ee1","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"04:38:46Z","name":"go-test-lb-fi-hel2-1686162646","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:46.802251Z"},{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:46.802251Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:46.802251Z","uuid":"0abd8219-74c6-4294-be0b-7a51919e76ef","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:34 GMT
+      - Wed, 07 Jun 2023 18:30:46 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1648824575","plan":"development","zone":"fi-hel2","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162647","plan":"development","zone":"fi-hel2","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -109,25 +110,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:35.668452Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:11:10Z","name":"go-test-lb-fi-hel2-1686162647","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:47.976238Z"},{"created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:47.976238Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:47.976238Z","uuid":"0a9b5830-612c-45fb-9a86-8b385f80f86a","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:35 GMT
+      - Wed, 07 Jun 2023 18:30:48 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1648824576","plan":"development","zone":"fi-hel2","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162648","plan":"development","zone":"fi-hel2","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -135,25 +136,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:36.753558Z","dns_name":"lb-0a817c2cc80c4d4a9c8b7e655863785b.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824576","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:36.753558Z","uuid":"0a817c2c-c80c-4d4a-9c8b-7e655863785b","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"04:09:52Z","name":"go-test-lb-fi-hel2-1686162648","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:49.1449Z"},{"created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:49.1449Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:49.1449Z","uuid":"0a465f91-b417-47fa-9af7-4ad3f38148d0","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "975"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:36 GMT
+      - Wed, 07 Jun 2023 18:30:49 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-fi-hel2-1648824577","plan":"development","zone":"fi-hel2","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-fi-hel2-1686162650","plan":"development","zone":"fi-hel2","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -161,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:37.816879Z","dns_name":"lb-0af04bfa8cfb4e7098142d3dccf3182d.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824577","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:37.816879Z","uuid":"0af04bfa-8cfb-4e70-9814-2d3dccf3182d","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:50.306976Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "431"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:37 GMT
+      - Wed, 07 Jun 2023 18:30:50 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -187,18 +188,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=2&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:33.554792Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:34.600087Z","dns_name":"lb-0af7700eb82e40e3baafbc0870730ee1.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824574","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:34.614662Z","uuid":"0af7700e-b82e-40e3-baaf-bc0870730ee1","zone":"fi-hel2"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:45.757623Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"04:38:46Z","name":"go-test-lb-fi-hel2-1686162646","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:46.802251Z"},{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:46.802251Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:46.969853Z","uuid":"0abd8219-74c6-4294-be0b-7a51919e76ef","zone":"fi-hel2"}]'
     headers:
-      Content-Length:
-      - "875"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:38 GMT
+      - Wed, 07 Jun 2023 18:30:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -213,18 +212,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=2&offset=2
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:35.685406Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:36.753558Z","dns_name":"lb-0a817c2cc80c4d4a9c8b7e655863785b.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824576","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:36.769727Z","uuid":"0a817c2c-c80c-4d4a-9c8b-7e655863785b","zone":"fi-hel2"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"02:11:10Z","name":"go-test-lb-fi-hel2-1686162647","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:47.976238Z"},{"created_at":"2023-06-07T18:30:47.976238Z","dns_name":"lb-0a9b5830612c45fb9a868b385f80f86a-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:47.976238Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:48.128889Z","uuid":"0a9b5830-612c-45fb-9a86-8b385f80f86a","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"04:09:52Z","name":"go-test-lb-fi-hel2-1686162648","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:49.1449Z"},{"created_at":"2023-06-07T18:30:49.1449Z","dns_name":"lb-0a465f91b41747fa9af74ad3f38148d0-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:49.1449Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:49.269442Z","uuid":"0a465f91-b417-47fa-9af7-4ad3f38148d0","zone":"fi-hel2"}]'
     headers:
-      Content-Length:
-      - "875"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:38 GMT
+      - Wed, 07 Jun 2023 18:30:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -239,18 +236,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=2&offset=4
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:37.816879Z","dns_name":"lb-0af04bfa8cfb4e7098142d3dccf3182d.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824577","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:37.836474Z","uuid":"0af04bfa-8cfb-4e70-9814-2d3dccf3182d","zone":"fi-hel2"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:50.550167Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}]'
     headers:
       Content-Length:
-      - "438"
+      - "1039"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:38 GMT
+      - Wed, 07 Jun 2023 18:30:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -265,18 +262,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=2&offset=0
     method: GET
   response:
-    body: '[{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:33.554792Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:34.600087Z","dns_name":"lb-0af7700eb82e40e3baafbc0870730ee1.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824574","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:34.614662Z","uuid":"0af7700e-b82e-40e3-baaf-bc0870730ee1","zone":"fi-hel2"}]'
+    body: '[{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:45.757623Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"},{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"04:38:46Z","name":"go-test-lb-fi-hel2-1686162646","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:46.802251Z"},{"created_at":"2023-06-07T18:30:46.802251Z","dns_name":"lb-0abd821974c64294be0b7a51919e76ef-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:46.802251Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"setup-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:46.969853Z","uuid":"0abd8219-74c6-4294-be0b-7a51919e76ef","zone":"fi-hel2"}]'
     headers:
-      Content-Length:
-      - "875"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:51 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -291,14 +286,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -313,14 +308,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af7700e-b82e-40e3-baaf-bc0870730ee1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0abd8219-74c6-4294-be0b-7a51919e76ef
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -335,14 +330,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a9b5830-612c-45fb-9a86-8b385f80f86a
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -357,14 +352,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a817c2c-c80c-4d4a-9c8b-7e655863785b
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a465f91-b417-47fa-9af7-4ad3f38148d0
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -379,14 +374,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af04bfa-8cfb-4e70-9814-2d3dccf3182d
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -401,18 +396,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:39 GMT
+      - Wed, 07 Jun 2023 18:30:52 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -427,18 +422,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:41 GMT
+      - Wed, 07 Jun 2023 18:30:54 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -453,18 +448,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:43 GMT
+      - Wed, 07 Jun 2023 18:30:56 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -479,18 +474,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:45 GMT
+      - Wed, 07 Jun 2023 18:30:59 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -505,18 +500,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:47 GMT
+      - Wed, 07 Jun 2023 18:31:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -531,18 +526,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:49 GMT
+      - Wed, 07 Jun 2023 18:31:03 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -557,18 +552,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:51 GMT
+      - Wed, 07 Jun 2023 18:31:05 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -583,18 +578,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:53 GMT
+      - Wed, 07 Jun 2023 18:31:07 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -609,18 +604,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:55 GMT
+      - Wed, 07 Jun 2023 18:31:09 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -635,18 +630,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:57 GMT
+      - Wed, 07 Jun 2023 18:31:11 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -661,18 +656,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:49:59 GMT
+      - Wed, 07 Jun 2023 18:31:14 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -687,18 +682,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:01 GMT
+      - Wed, 07 Jun 2023 18:31:16 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -713,18 +708,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:03 GMT
+      - Wed, 07 Jun 2023 18:31:18 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -739,18 +734,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:05 GMT
+      - Wed, 07 Jun 2023 18:31:20 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -765,18 +760,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:08 GMT
+      - Wed, 07 Jun 2023 18:31:22 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -791,18 +786,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:10 GMT
+      - Wed, 07 Jun 2023 18:31:24 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -817,18 +812,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:12 GMT
+      - Wed, 07 Jun 2023 18:31:26 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -843,18 +838,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:14 GMT
+      - Wed, 07 Jun 2023 18:31:28 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -869,18 +864,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:16 GMT
+      - Wed, 07 Jun 2023 18:31:31 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -895,18 +890,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:18 GMT
+      - Wed, 07 Jun 2023 18:31:33 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -921,18 +916,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:20 GMT
+      - Wed, 07 Jun 2023 18:31:35 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -947,18 +942,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:22 GMT
+      - Wed, 07 Jun 2023 18:31:37 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -973,18 +968,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:24 GMT
+      - Wed, 07 Jun 2023 18:31:39 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -999,18 +994,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:26 GMT
+      - Wed, 07 Jun 2023 18:31:41 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1025,18 +1020,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:28 GMT
+      - Wed, 07 Jun 2023 18:31:43 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1051,18 +1046,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:30 GMT
+      - Wed, 07 Jun 2023 18:31:45 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1077,18 +1072,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:32 GMT
+      - Wed, 07 Jun 2023 18:31:48 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1103,18 +1098,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:33.538326Z","dns_name":"lb-0a71143362b54df4980f67c04710be4f.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824573","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.096248Z","uuid":"0a711433-62b5-4df4-980f-67c04710be4f","zone":"fi-hel2"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
     headers:
       Content-Length:
-      - "437"
+      - "1040"
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:34 GMT
+      - Wed, 07 Jun 2023 18:31:50 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -1129,12 +1124,1416 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a711433-62b5-4df4-980f-67c04710be4f
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:31:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:31:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:31:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:31:58 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:00 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:09 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:11 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:13 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:15 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:17 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:22 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:24 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:26 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:28 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:30 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:32 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:34 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:36 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:39 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:51 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:32:58 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:00 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:06 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:08 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:11 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:13 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:15 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:17 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:21 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:25 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:28 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:30 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:32 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:34 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:36 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:38 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:40 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"saturday","maintenance_time":"05:09:07Z","name":"go-test-lb-fi-hel2-1686162645","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:45.625882Z"},{"created_at":"2023-06-07T18:30:45.625882Z","dns_name":"lb-0a4b7f4b30d84a629d6caf701f3ce3e4-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:45.625882Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:52.201522Z","uuid":"0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1040"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4b7f4b-30d8-4a62-9d6c-af701f3ce3e4
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJSPN9ZT37FTD27EQ7Y64N6","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJ5SW15E5QRZ7PB3B0QJ2Z","status":404}
     headers:
       Content-Language:
       - en
@@ -1143,7 +2542,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 14:50:36 GMT
+      - Wed, 07 Jun 2023 18:33:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1158,64 +2557,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af7700e-b82e-40e3-baaf-bc0870730ee1
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:34.600087Z","dns_name":"lb-0af7700eb82e40e3baafbc0870730ee1.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824574","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.152506Z","uuid":"0af7700e-b82e-40e3-baaf-bc0870730ee1","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:36 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af7700e-b82e-40e3-baaf-bc0870730ee1
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:34.600087Z","dns_name":"lb-0af7700eb82e40e3baafbc0870730ee1.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824574","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.152506Z","uuid":"0af7700e-b82e-40e3-baaf-bc0870730ee1","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:38 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af7700e-b82e-40e3-baaf-bc0870730ee1
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0abd8219-74c6-4294-be0b-7a51919e76ef
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJSPSBT8EFFWNTC0ED9AG9F","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJ5SZ0M8ZJM4X3M78QNECH","status":404}
     headers:
       Content-Language:
       - en
@@ -1224,7 +2571,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 14:50:40 GMT
+      - Wed, 07 Jun 2023 18:33:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1239,142 +2586,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.198361Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:40 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.198361Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:43 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.198361Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:45 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.198361Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:47 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
-    method: GET
-  response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-04-01T14:49:35.668452Z","dns_name":"lb-0a9cace5fb3f4522afaa30830c3cdc0c.upcloudlb.com","frontends":[],"name":"go-test-lb-fi-hel2-1648824575","network_uuid":"03dacc38-b334-4fd5-826c-3a351b884770","operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-04-01T14:49:39.198361Z","uuid":"0a9cace5-fb3f-4522-afaa-30830c3cdc0c","zone":"fi-hel2"}'
-    headers:
-      Content-Length:
-      - "437"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 14:50:49 GMT
-      Strict-Transport-Security:
-      - max-age=63072000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a9cace5-fb3f-4522-afaa-30830c3cdc0c
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a9b5830-612c-45fb-9a86-8b385f80f86a
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJSQ3E9HVXQW02SXFXFKMCY","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJ5T1ZMA97BDEMTDKNS3MK","status":404}
     headers:
       Content-Language:
       - en
@@ -1383,7 +2600,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 14:50:51 GMT
+      - Wed, 07 Jun 2023 18:33:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1398,12 +2615,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a817c2c-c80c-4d4a-9c8b-7e655863785b
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a465f91-b417-47fa-9af7-4ad3f38148d0
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJSQ3FNKDNFDQ9B76TTV6SX","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJ5T5G78DA5F4R8H774YV1","status":404}
     headers:
       Content-Language:
       - en
@@ -1412,7 +2629,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 14:50:51 GMT
+      - Wed, 07 Jun 2023 18:33:47 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1427,12 +2644,194 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/load-balancer/0af04bfa-8cfb-4e70-9814-2d3dccf3182d
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:51 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:33:58 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:40:15Z","name":"go-test-lb-fi-hel2-1686162650","network_uuid":"036b8041-6759-4820-80a1-0a2471da241f","networks":[{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:30:50.306976Z"},{"created_at":"2023-06-07T18:30:50.306976Z","dns_name":"lb-0aca4f05889142998726433f641eb2fd-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:30:50.306976Z","uuid":"036b8041-6759-4820-80a1-0a2471da241f"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:30:59.015693Z","uuid":"0aca4f05-8891-4299-8726-433f641eb2fd","zone":"fi-hel2"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:34:00 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0aca4f05-8891-4299-8726-433f641eb2fd
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01FZJSQ3GZJ61EQNB0M4MCD6P4","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BJ68SSJGD6MCXS2PAPCDPK","status":404}
     headers:
       Content-Language:
       - en
@@ -1441,7 +2840,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Fri, 01 Apr 2022 14:50:51 GMT
+      - Wed, 07 Jun 2023 18:34:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -1456,14 +2855,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
-    url: https://api.upcloud.com/1.3/network/03dacc38-b334-4fd5-826c-3a351b884770
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/036b8041-6759-4820-80a1-0a2471da241f
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Fri, 01 Apr 2022 14:50:51 GMT
+      - Wed, 07 Jun 2023 18:34:02 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -1480,7 +2879,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.0.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer?limit=100&offset=0
     method: GET
   response:
@@ -1491,7 +2890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 14:50:51 GMT
+      - Wed, 07 Jun 2023 18:34:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK

--- a/upcloud/service/fixtures/loadbalancerresolver.yaml
+++ b/upcloud/service/fixtures/loadbalancerresolver.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"network":{"name":"go-test-lb-1666617503","zone":"pl-waw1","ip_networks":{"ip_network":[{"address":"10.0.0.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
+    body: '{"network":{"name":"go-test-lb-1686161700","zone":"pl-waw1","ip_networks":{"ip_network":[{"address":"10.0.0.0/24","dhcp":"yes","dhcp_default_route":"no","family":"IPv4"}]}}}'
     form: {}
     headers:
       Accept:
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
@@ -28,19 +28,20 @@ interactions:
                   }
                ]
             },
-            "name" : "go-test-lb-1666617503",
+            "labels" : [],
+            "name" : "go-test-lb-1686161700",
             "type" : "private",
-            "uuid" : "039d51f0-632f-481c-b07a-151ac070c975",
+            "uuid" : "03c8c521-f0ce-41a1-a7ef-c4515d46b415",
             "zone" : "pl-waw1"
          }
       }
     headers:
       Content-Length:
-      - "459"
+      - "480"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 24 Oct 2022 13:18:23 GMT
+      - Wed, 07 Jun 2023 18:15:00 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -49,7 +50,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"go-test-lb-pl-waw1-1666617504","plan":"development","zone":"pl-waw1","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
+    body: '{"name":"go-test-lb-pl-waw1-1686161701","plan":"development","zone":"pl-waw1","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","configured_status":"started","frontends":[],"backends":[],"resolvers":[]}'
     form: {}
     headers:
       Accept:
@@ -57,18 +58,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
+      - upcloud-go-api/6.3.1
     url: https://api.upcloud.com/1.3/load-balancer
     method: POST
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:24.334668Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:01.172673Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "442"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:24 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -83,18 +84,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers
     method: POST
   response:
-    body: '{"cache_invalid":321,"cache_valid":123,"created_at":"2022-10-24T13:18:24.528311Z","name":"testname","nameservers":["10.0.0.1","10.0.0.2"],"retries":10,"timeout":20,"timeout_retry":10,"updated_at":"2022-10-24T13:18:24.528311Z"}'
+    body: '{"cache_invalid":321,"cache_valid":123,"created_at":"2023-06-07T18:15:01.34095Z","name":"testname","nameservers":["10.0.0.1","10.0.0.2"],"retries":10,"timeout":20,"timeout_retry":10,"updated_at":"2023-06-07T18:15:01.34095Z"}'
     headers:
       Content-Length:
-      - "226"
+      - "224"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:24 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 201 Created
@@ -109,18 +110,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers/testname
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers/testname
     method: PATCH
   response:
-    body: '{"cache_invalid":321,"cache_valid":123,"created_at":"2022-10-24T13:18:24.528311Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":10,"updated_at":"2022-10-24T13:18:24.702038Z"}'
+    body: '{"cache_invalid":321,"cache_valid":123,"created_at":"2023-06-07T18:15:01.34095Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":10,"updated_at":"2023-06-07T18:15:01.487422Z"}'
     headers:
       Content-Length:
-      - "244"
+      - "243"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:24 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -135,18 +136,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers/updated_testname
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers/updated_testname
     method: PATCH
   response:
-    body: '{"cache_invalid":324,"cache_valid":124,"created_at":"2022-10-24T13:18:24.528311Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2022-10-24T13:18:24.920538Z"}'
+    body: '{"cache_invalid":324,"cache_valid":124,"created_at":"2023-06-07T18:15:01.34095Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2023-06-07T18:15:01.627829Z"}'
     headers:
       Content-Length:
-      - "244"
+      - "243"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:24 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -161,18 +162,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers/updated_testname
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers/updated_testname
     method: GET
   response:
-    body: '{"cache_invalid":324,"cache_valid":124,"created_at":"2022-10-24T13:18:24.528311Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2022-10-24T13:18:24.920538Z"}'
+    body: '{"cache_invalid":324,"cache_valid":124,"created_at":"2023-06-07T18:15:01.34095Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2023-06-07T18:15:01.627829Z"}'
     headers:
       Content-Length:
-      - "244"
+      - "243"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:25 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -187,18 +188,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers
     method: GET
   response:
-    body: '[{"cache_invalid":324,"cache_valid":124,"created_at":"2022-10-24T13:18:24.528311Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2022-10-24T13:18:24.920538Z"}]'
+    body: '[{"cache_invalid":324,"cache_valid":124,"created_at":"2023-06-07T18:15:01.34095Z","name":"updated_testname","nameservers":["10.0.0.1","10.0.0.2","10.0.0.3"],"retries":5,"timeout":30,"timeout_retry":15,"updated_at":"2023-06-07T18:15:01.627829Z"}]'
     headers:
       Content-Length:
-      - "246"
+      - "245"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:25 GMT
+      - Wed, 07 Jun 2023 18:15:01 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -213,14 +214,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api-ctx/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61/resolvers/updated_testname
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533/resolvers/updated_testname
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Mon, 24 Oct 2022 13:18:25 GMT
+      - Wed, 07 Jun 2023 18:15:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -235,14 +236,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Mon, 24 Oct 2022 13:18:25 GMT
+      - Wed, 07 Jun 2023 18:15:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 204 No Content
@@ -257,18 +258,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:25.623135Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "507"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:25 GMT
+      - Wed, 07 Jun 2023 18:15:02 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -283,18 +284,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:25.623135Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "507"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:27 GMT
+      - Wed, 07 Jun 2023 18:15:04 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -309,18 +310,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:25.623135Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "507"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:30 GMT
+      - Wed, 07 Jun 2023 18:15:06 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -335,18 +336,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:32 GMT
+      - Wed, 07 Jun 2023 18:15:08 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -361,18 +362,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:34 GMT
+      - Wed, 07 Jun 2023 18:15:10 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -387,18 +388,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:36 GMT
+      - Wed, 07 Jun 2023 18:15:12 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -413,18 +414,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"pending","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:02.165855Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1032"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:38 GMT
+      - Wed, 07 Jun 2023 18:15:15 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -439,18 +440,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:41 GMT
+      - Wed, 07 Jun 2023 18:15:17 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -465,18 +466,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:43 GMT
+      - Wed, 07 Jun 2023 18:15:19 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -491,18 +492,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:45 GMT
+      - Wed, 07 Jun 2023 18:15:21 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -517,18 +518,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:47 GMT
+      - Wed, 07 Jun 2023 18:15:23 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -543,18 +544,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:49 GMT
+      - Wed, 07 Jun 2023 18:15:25 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -569,18 +570,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:52 GMT
+      - Wed, 07 Jun 2023 18:15:27 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -595,18 +596,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:54 GMT
+      - Wed, 07 Jun 2023 18:15:30 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -621,18 +622,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:56 GMT
+      - Wed, 07 Jun 2023 18:15:32 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -647,18 +648,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:18:58 GMT
+      - Wed, 07 Jun 2023 18:15:34 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -673,18 +674,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:19:01 GMT
+      - Wed, 07 Jun 2023 18:15:36 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -699,18 +700,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:19:03 GMT
+      - Wed, 07 Jun 2023 18:15:38 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -725,18 +726,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
-    body: '{"backends":[],"configured_status":"started","created_at":"2022-10-24T13:18:24.334668Z","dns_name":"lb-0a278537c53b462d92dfc0b4f272da61.upcloudlb.com","frontends":[],"name":"go-test-lb-pl-waw1-1666617504","network_uuid":"039d51f0-632f-481c-b07a-151ac070c975","nodes":[{"backend_ip":"","frontend_ips":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2022-10-24T13:18:30.652749Z","uuid":"0a278537-c53b-462d-92df-c0b4f272da61","zone":"pl-waw1"}'
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
     headers:
       Content-Length:
-      - "513"
+      - "1038"
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 13:19:05 GMT
+      - Wed, 07 Jun 2023 18:15:40 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
@@ -751,12 +752,220 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/load-balancer/0a278537-c53b-462d-92df-c0b4f272da61
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:51 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
+    method: GET
+  response:
+    body: '{"backends":[],"configured_status":"started","created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","frontends":[],"labels":[],"maintenance_dow":"sunday","maintenance_time":"00:59:11Z","name":"go-test-lb-pl-waw1-1686161701","network_uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415","networks":[{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-1.upcloudlb.com","family":"IPv4","name":"public-IPv4","type":"public","updated_at":"2023-06-07T18:15:01.172673Z"},{"created_at":"2023-06-07T18:15:01.172673Z","dns_name":"lb-0a4cd9cac8d049d383d9c32d6b1f5533-2.upcloudlb.com","family":"IPv4","name":"private-IPv4","type":"private","updated_at":"2023-06-07T18:15:01.172673Z","uuid":"03c8c521-f0ce-41a1-a7ef-c4515d46b415"}],"nodes":[{"networks":[],"operational_state":"pending"}],"operational_state":"delete-server","plan":"development","resolvers":[],"updated_at":"2023-06-07T18:15:15.167223Z","uuid":"0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533","zone":"pl-waw1"}'
+    headers:
+      Content-Length:
+      - "1038"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Jun 2023 18:15:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/load-balancer/0a4cd9ca-c8d0-49d3-83d9-c32d6b1f5533
     method: GET
   response:
     body: |
-      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01GG52B6TXNXZFEVTGFQGE5G7W","status":404}
+      {"type":"https://developers.upcloud.com/1.3/errors#ERROR_RESOURCE_NOT_FOUND","title":"Service not found.","correlation_id":"01H2BH57NFSEKC66NKJWAJQDX8","status":404}
     headers:
       Content-Language:
       - en
@@ -765,7 +974,7 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Mon, 24 Oct 2022 13:19:07 GMT
+      - Wed, 07 Jun 2023 18:15:59 GMT
       Strict-Transport-Security:
       - max-age=63072000
     status: 404 Not Found
@@ -780,14 +989,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/4.9.0
-    url: https://api.upcloud.com/1.3/network/039d51f0-632f-481c-b07a-151ac070c975
+      - upcloud-go-api/6.3.1
+    url: https://api.upcloud.com/1.3/network/03c8c521-f0ce-41a1-a7ef-c4515d46b415
     method: DELETE
   response:
     body: ""
     headers:
       Date:
-      - Mon, 24 Oct 2022 13:19:07 GMT
+      - Wed, 07 Jun 2023 18:16:00 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/load_balancer_test.go
+++ b/upcloud/service/load_balancer_test.go
@@ -22,10 +22,10 @@ func TestLoadBalancer(t *testing.T) {
 		// Create Load Balancer
 		lb, err := createLoadBalancerAndNetwork(ctx, svc, "fi-hel1", "172.16.1.0/24")
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 		t.Logf("Created load balancer: %s", lb.Name)
 
 		// Modify Load Balancer
@@ -62,10 +62,10 @@ func TestLoadBalancerBackend(t *testing.T) {
 	record(t, "loadbalancerbackend", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
 		lb, err := createLoadBalancerAndNetwork(ctx, svc, "fi-hel2", "172.16.2.0/24")
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 
 		t.Logf("Created load balancer for testing LB backend CRUD: %s", lb.Name)
 
@@ -126,10 +126,10 @@ func TestLoadBalancerBackendMember(t *testing.T) {
 	record(t, "loadbalancerbackendmember", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
 		lb, err := createLoadBalancerAndNetwork(ctx, svc, "nl-ams1", "172.16.3.0/24")
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 		t.Logf("Created load balancer for testing LB backend members CRUD: %s", lb.Name)
 
 		backend, err := createLoadBalancerBackend(ctx, svc, lb.UUID)
@@ -248,10 +248,10 @@ func TestLoadBalancerResolver(t *testing.T) {
 	record(t, "loadbalancerresolver", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
 		lb, err := createLoadBalancerAndNetwork(ctx, svc, "pl-waw1", "10.0.0.0/24")
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 		t.Logf("Created load balancer for testing LB resolvers CRUD: %s", lb.Name)
 
 		name := "testname"
@@ -382,10 +382,10 @@ func TestLoadBalancerFrontend(t *testing.T) {
 	record(t, "loadbalancerfrontend", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
 		lb, err := createLoadBalancerAndNetwork(ctx, svc, "de-fra1", "10.0.3.0/24")
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 		t.Logf("Created LB for testing frontends: %s", lb.Name)
 		be, err := createLoadBalancerBackend(ctx, svc, lb.UUID)
 		require.NoError(t, err)
@@ -484,12 +484,10 @@ func TestLoadBalancerFrontendRule(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			cCtx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
-			defer cancel()
-			err := cleanupLoadBalancer(cCtx, rec, svc, lb)
+		defer func() {
+			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 		rule, err := svc.CreateLoadBalancerFrontendRule(ctx, &request.CreateLoadBalancerFrontendRuleRequest{
 			ServiceUUID:  lb.UUID,
 			FrontendName: lb.Frontends[0].Name,
@@ -639,10 +637,10 @@ func TestLoadBalancerCerticateBundlesAndFrontendTLSConfigs(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 
 		mc, err := svc.CreateLoadBalancerCertificateBundle(ctx, &request.CreateLoadBalancerCertificateBundleRequest{
 			Type:        upcloud.LoadBalancerCertificateBundleTypeManual,
@@ -871,10 +869,10 @@ func TestLoadBalancerNetwork(t *testing.T) {
 			Resolvers: make([]request.LoadBalancerResolver, 0),
 		})
 		require.NoError(t, err)
-		t.Cleanup(func() {
+		defer func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
 			assert.NoError(t, err)
-		})
+		}()
 
 		t.Logf("Testing LB %s properties", lb.Name)
 		assert.Len(t, lb.Networks, 2)
@@ -955,16 +953,14 @@ func TestLoadBalancerLabels(t *testing.T) {
 		lb2, err := createLoadBalancerAndNetwork(ctx, svc, "fi-hel1", "172.16.14.0/24", upcloud.Label{Key: "zone", Value: "hel1"})
 		require.NoError(t, err)
 		t.Logf("Created load balancer: %s", lb2.Name)
-		t.Cleanup(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
+		defer func() {
 			if err := cleanupLoadBalancer(ctx, rec, svc, lb1); err != nil {
 				t.Log(err)
 			}
 			if err := cleanupLoadBalancer(ctx, rec, svc, lb2); err != nil {
 				t.Log(err)
 			}
-		})
+		}()
 
 		// Get Load Balancers
 		t.Log("Get load balancers labeled as 'zone'")
@@ -1062,11 +1058,7 @@ func cleanupLoadBalancer(ctx context.Context, rec *recorder.Recorder, svc *Servi
 	if rec.Mode() != recorder.ModeRecording {
 		return nil
 	}
-	rec.AddPassthrough(func(h *http.Request) bool {
-		return true
-	})
 	err := deleteLoadBalancer(ctx, svc, lb)
-	rec.Passthroughs = nil
 	return err
 }
 

--- a/upcloud/service/load_balancer_test.go
+++ b/upcloud/service/load_balancer_test.go
@@ -380,7 +380,7 @@ func TestLoadBalancerFrontend(t *testing.T) {
 	t.Parallel()
 
 	record(t, "loadbalancerfrontend", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
-		lb, err := createLoadBalancerAndNetwork(ctx, svc, "de-fra1", "10.0.0.1/24")
+		lb, err := createLoadBalancerAndNetwork(ctx, svc, "de-fra1", "10.0.3.0/24")
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err := cleanupLoadBalancer(ctx, rec, svc, lb)
@@ -607,7 +607,7 @@ func TestLoadBalancerCerticateBundlesAndFrontendTLSConfigs(t *testing.T) {
 	t.Parallel()
 
 	record(t, "loadbalancercerticatebundlesandfrontendtlsconfigs", func(ctx context.Context, t *testing.T, rec *recorder.Recorder, svc *Service) {
-		net, err := createLoadBalancerAndPrivateNetwork(ctx, svc, "fi-hel1", "10.0.1.1/24")
+		net, err := createLoadBalancerAndPrivateNetwork(ctx, svc, "fi-hel1", "10.0.4.0/24")
 		require.NoError(t, err)
 		feName := "fe-1"
 		lb, err := svc.CreateLoadBalancer(ctx, &request.CreateLoadBalancerRequest{


### PR DESCRIPTION
- Add support for LB backend member property `health_check_tls_verify`. If enabled, no TLS certificate validation is done for backend members that are using `https` scheme for health checks.
- Fix LB service tests.
  - Use valid CIDR ranges.
  - Change `t.Cleanup()` to `defer` to match how other tests are handling cleanup. Worth noting that `t.Cleanup()` does not work as recorder cancels the test `ctx` as soon as the test has concluded.
  - LB `DELETE` calls were present in fixtures but they were explicitly being passed through by the recorder. Now fixtures and tests are aligned.
- Update LB fixtures.