### PR TITLE
refactor(client): new http.Client init function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- client functions `NewDefaultHTTPClient` and `NewDefaultHTTPTransport` to provide HTTP client default properties
+
 ## [6.3.2]
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.2.0
-	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/stretchr/testify v1.7.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
-github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -254,7 +253,7 @@ func NewDefaultHTTPClient() *http.Client {
 
 // NewDefaultHTTPTransport return new HTTP client transport round tripper.
 func NewDefaultHTTPTransport() http.RoundTripper {
-	transport := &http.Transport{
+	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -266,9 +265,7 @@ func NewDefaultHTTPTransport() http.RoundTripper {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		DisableKeepAlives:     true,
+		MaxIdleConnsPerHost:   -1,
 	}
-	transport.DisableKeepAlives = true
-	transport.MaxIdleConnsPerHost = -1
-	return transport
 }

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -6,13 +6,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 const (
@@ -189,7 +189,7 @@ func New(username, password string, c ...ConfigFn) *Client {
 		username:   username,
 		password:   password,
 		baseURL:    clientBaseURL(os.Getenv(EnvDebugAPIBaseURL)),
-		httpClient: cleanhttp.DefaultClient(),
+		httpClient: NewDefaultHTTPClient(),
 	}
 
 	// If set, replace http client transport with one skipping tls verification
@@ -242,4 +242,33 @@ func handleResponse(response *http.Response) ([]byte, error) {
 	responseBody, err := io.ReadAll(response.Body)
 
 	return responseBody, err
+}
+
+// NewDefaultHTTPClient returns new default http.Client.
+func NewDefaultHTTPClient() *http.Client {
+	transport := NewDefaultHTTPTransport()
+	return &http.Client{
+		Transport: transport,
+	}
+}
+
+// NewDefaultHTTPTransport return new HTTP client transport round tripper.
+func NewDefaultHTTPTransport() http.RoundTripper {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+	}
+	transport.DisableKeepAlives = true
+	transport.MaxIdleConnsPerHost = -1
+	return transport
 }

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,7 +76,7 @@ func record(t *testing.T, fixture string, f func(context.Context, *testing.T, *r
 
 	user, password := getCredentials()
 
-	httpClient := cleanhttp.DefaultClient()
+	httpClient := client.NewDefaultHTTPClient()
 	origTransport := httpClient.Transport
 	r.SetTransport(origTransport)
 	httpClient.Transport = r


### PR DESCRIPTION
This replaces  `go-cleanhttp`  dependency with `NewDefaultHTTPClient` and `NewDefaultHTTPTransport` functions. Functions are exported so that client and/or transport can be easily modified by user if needed. 

HTTP client properties should be identical to what was previously, except for `ForceAttemptHTTP2`, which is also set in latest `go-cleanhttp` package.