### PR TITLE
chore: use Go 1.19

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         # support two latest major versions of Go, following the Go security policy
         # in which these versions get security updates. See https://golang.org/security
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x, 1.20.x]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,8 +10,6 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
-    - deadcode
-    - depguard
     - dogsled
     - errcheck
     - goconst
@@ -31,13 +29,11 @@ linters:
     - predeclared
     - rowserrcheck
     - staticcheck
-    - structcheck
     # - stylecheck # TODO: re-enable, needs breaking change due to wanting IpAddress -> IPAddress
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 test: check-test-env
 	go test ./... -parallel 8
 
+.PHONY: lint
+lint:
+	golangci-lint run
+
 check-test-env:
 ifndef UPCLOUD_GO_SDK_TEST_USER
 	$(error UPCLOUD_GO_SDK_TEST_USER is undefined)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-go-api/v6
 
-go 1.18
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
- Use Go 1.19 in `go.mod` and CI actions
- Test against two previous Go major releases (1.19, 1.20) and drop out 1.18
- Remove deprecated linters
- Add make command for `lint` :) 