### PR TITLE
fix(kubernetes): sleep before `GET` request in `WaitForKubernetesClusterState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ## Added
 - kubernetes: `WaitForKubernetesNodeGroupState` method for waiting the node group to achieve a desired state
 
+### Changed
+- kubernetes: sleep before `GET` request in `WaitForKubernetesClusterState`
+
 ## [6.8.2]
 ### Added
 - account: `NetworkPeerings`, `NTPExcessGiB`, `StorageMaxIOPS`, and `LoadBalancers` fields to the `ResourceLimits` struct.

--- a/upcloud/service/kubernetes.go
+++ b/upcloud/service/kubernetes.go
@@ -82,6 +82,7 @@ func (s *Service) WaitForKubernetesClusterState(ctx context.Context, r *request.
 
 	for {
 		attempts++
+		time.Sleep(sleepDuration)
 
 		details, err := s.GetKubernetesCluster(ctx, &request.GetKubernetesClusterRequest{
 			UUID: r.UUID,
@@ -99,8 +100,6 @@ func (s *Service) WaitForKubernetesClusterState(ctx context.Context, r *request.
 		if details.State == r.DesiredState {
 			return details, nil
 		}
-
-		time.Sleep(sleepDuration)
 
 		if time.Duration(attempts)*sleepDuration >= r.Timeout {
 			return nil, fmt.Errorf("timeout reached while waiting for Kubernetes cluster to enter state \"%s\"", r.DesiredState)


### PR DESCRIPTION
Sleep before `GET` request in `WaitForKubernetesClusterState` to avoid getting stale state in some scenarios. This will also align function behavior with other services.