### PR TITLE
refactor: remove `Timeout` option from `WaitFor*` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - **Breaking**, Managed Database: connection related methods in favor of session
+- **Breaking**: remove `Timeout` option from `WaitFor*` methods. Use `context.WithTimeout` to define a timeout for these functions.
 
 ## [6.12.0]
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ fmt.Println(fmt.Sprintf("Server %s with UUID %s created", serverDetails.Title, s
 err = svc.WaitForServerState(context.Background(), &request.WaitForServerStateRequest{
 	UUID:         serverDetails.UUID,
 	DesiredState: upcloud.ServerStateStarted,
-	Timeout:      time.Minute * 5,
 })
 
 if err != nil {

--- a/examples/upcloud-cli/main.go
+++ b/examples/upcloud-cli/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/client"
@@ -121,7 +120,6 @@ func createServer(s *service.Service) error {
 	details, err = s.WaitForServerState(ctx, &request.WaitForServerStateRequest{
 		UUID:         details.UUID,
 		DesiredState: upcloud.ServerStateStarted,
-		Timeout:      1 * time.Minute,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to wait for server: %#v", err)
@@ -160,7 +158,6 @@ func deleteServers(s *service.Service) error {
 				_, err = s.WaitForServerState(ctx, &request.WaitForServerStateRequest{
 					UUID:         server.UUID,
 					DesiredState: upcloud.ServerStateStopped,
-					Timeout:      1 * time.Minute,
 				})
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to wait for server to reach desired state: %#v", err)

--- a/upcloud/request/kubernetes.go
+++ b/upcloud/request/kubernetes.go
@@ -3,7 +3,6 @@ package request
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 )
@@ -93,7 +92,6 @@ func (r *DeleteKubernetesClusterRequest) RequestURL() string {
 // to enter a desired state
 type WaitForKubernetesClusterStateRequest struct {
 	DesiredState upcloud.KubernetesClusterState `json:"-"`
-	Timeout      time.Duration                  `json:"-"`
 	UUID         string                         `json:"-"`
 }
 
@@ -105,7 +103,6 @@ func (r *WaitForKubernetesClusterStateRequest) RequestURL() string {
 // to enter a desired state
 type WaitForKubernetesNodeGroupStateRequest struct {
 	DesiredState upcloud.KubernetesNodeGroupState `json:"-"`
-	Timeout      time.Duration                    `json:"-"`
 	ClusterUUID  string                           `json:"-"`
 	Name         string                           `json:"-"`
 }

--- a/upcloud/request/managed_database.go
+++ b/upcloud/request/managed_database.go
@@ -477,7 +477,6 @@ func (r *GetManagedDatabaseVersionsRequest) RequestURL() string {
 type WaitForManagedDatabaseStateRequest struct {
 	UUID         string
 	DesiredState upcloud.ManagedDatabaseState
-	Timeout      time.Duration
 }
 
 // StartManagedDatabaseRequest represents a request to start an existing managed database instance

--- a/upcloud/request/managed_object_storage.go
+++ b/upcloud/request/managed_object_storage.go
@@ -2,7 +2,6 @@ package request
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 )
@@ -291,7 +290,6 @@ func (r *DeleteManagedObjectStorageUserAccessKeyRequest) RequestURL() string {
 // to enter a desired state
 type WaitForManagedObjectStorageOperationalStateRequest struct {
 	DesiredState upcloud.ManagedObjectStorageOperationalState `json:"-"`
-	Timeout      time.Duration                                `json:"-"`
 	UUID         string                                       `json:"-"`
 }
 
@@ -304,7 +302,6 @@ func (r *WaitForManagedObjectStorageOperationalStateRequest) RequestURL() string
 // to enter a desired state
 type WaitForManagedObjectStorageUserOperationalStateRequest struct {
 	DesiredState upcloud.ManagedObjectStorageUserOperationalState `json:"-"`
-	Timeout      time.Duration                                    `json:"-"`
 	ServiceUUID  string                                           `json:"-"`
 	Username     string                                           `json:"-"`
 }
@@ -318,7 +315,6 @@ func (r *WaitForManagedObjectStorageUserOperationalStateRequest) RequestURL() st
 // to be deleted
 type WaitForManagedObjectStorageDeletionRequest struct {
 	DesiredState upcloud.ManagedObjectStorageOperationalState `json:"-"`
-	Timeout      time.Duration                                `json:"-"`
 	UUID         string                                       `json:"-"`
 }
 

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -229,7 +229,6 @@ type WaitForServerStateRequest struct {
 	UUID           string
 	DesiredState   string
 	UndesiredState string
-	Timeout        time.Duration
 }
 
 // StartServerRequest represents a request to start a server

--- a/upcloud/request/storage.go
+++ b/upcloud/request/storage.go
@@ -3,7 +3,6 @@ package request
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 )
@@ -238,7 +237,6 @@ func (r TemplatizeStorageRequest) MarshalJSON() ([]byte, error) {
 type WaitForStorageStateRequest struct {
 	UUID         string
 	DesiredState string
-	Timeout      time.Duration
 }
 
 // LoadCDROMRequest represents a request to load a storage as a CD-ROM in the CD-ROM device of a server
@@ -355,7 +353,6 @@ func (r *GetStorageImportDetailsRequest) RequestURL() string {
 // for storage import to complete.
 type WaitForStorageImportCompletionRequest struct {
 	StorageUUID string
-	Timeout     time.Duration
 }
 
 // ResizeStorageFilesystemRequest represents a request to resize storage filesystem

--- a/upcloud/service/kubernetes_test.go
+++ b/upcloud/service/kubernetes_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/client"
@@ -524,7 +523,6 @@ func TestWaitForKubernetesClusterState(t *testing.T) {
 	_, err := svc.WaitForKubernetesClusterState(context.Background(), &request.WaitForKubernetesClusterStateRequest{
 		UUID:         "_UUID_",
 		DesiredState: upcloud.KubernetesClusterStateRunning,
-		Timeout:      time.Second * 20,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 3, requestsMade)
@@ -584,7 +582,6 @@ func TestWaitForKubernetesNodeGroupState(t *testing.T) {
 	_, err := svc.WaitForKubernetesNodeGroupState(context.Background(), &request.WaitForKubernetesNodeGroupStateRequest{
 		ClusterUUID:  "_UUID_",
 		DesiredState: upcloud.KubernetesNodeGroupStateRunning,
-		Timeout:      time.Second * 20,
 		Name:         "_NAME_",
 	})
 	assert.NoError(t, err)

--- a/upcloud/service/managed_database_test.go
+++ b/upcloud/service/managed_database_test.go
@@ -997,7 +997,6 @@ func waitForManagedDatabaseRunningState(ctx context.Context, rec *recorder.Recor
 	_, err := svc.WaitForManagedDatabaseState(ctx, &request.WaitForManagedDatabaseStateRequest{
 		UUID:         dbUUID,
 		DesiredState: upcloud.ManagedDatabaseStateRunning,
-		Timeout:      waitTimeout,
 	})
 
 	return err

--- a/upcloud/service/managed_object_storage_test.go
+++ b/upcloud/service/managed_object_storage_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
@@ -414,7 +413,6 @@ func TestCreateManagedObjectStorageUserAccessKey(t *testing.T) {
 
 		_, err = svc.WaitForManagedObjectStorageUserOperationalState(context.Background(), &request.WaitForManagedObjectStorageUserOperationalStateRequest{
 			ServiceUUID:  storage.UUID,
-			Timeout:      time.Second * 90,
 			Username:     user.Username,
 			DesiredState: upcloud.ManagedObjectStorageUserOperationalStateReady,
 		})
@@ -446,7 +444,6 @@ func TestGetManagedObjectStorageUserAccesKeys(t *testing.T) {
 
 		_, err = svc.WaitForManagedObjectStorageUserOperationalState(context.Background(), &request.WaitForManagedObjectStorageUserOperationalStateRequest{
 			ServiceUUID:  storage.UUID,
-			Timeout:      time.Second * 90,
 			Username:     storage.Users[0].Username,
 			DesiredState: upcloud.ManagedObjectStorageUserOperationalStateReady,
 		})
@@ -481,7 +478,6 @@ func TestGetManagedObjectStorageUserAccessKey(t *testing.T) {
 
 		_, err = svc.WaitForManagedObjectStorageUserOperationalState(context.Background(), &request.WaitForManagedObjectStorageUserOperationalStateRequest{
 			ServiceUUID:  storage.UUID,
-			Timeout:      time.Second * 90,
 			Username:     storage.Users[0].Username,
 			DesiredState: upcloud.ManagedObjectStorageUserOperationalStateReady,
 		})
@@ -524,7 +520,6 @@ func TestModifyManagedObjectStorageUserAccessKey(t *testing.T) {
 
 		_, err = svc.WaitForManagedObjectStorageUserOperationalState(context.Background(), &request.WaitForManagedObjectStorageUserOperationalStateRequest{
 			ServiceUUID:  storage.UUID,
-			Timeout:      time.Second * 90,
 			Username:     storage.Users[0].Username,
 			DesiredState: upcloud.ManagedObjectStorageUserOperationalStateReady,
 		})
@@ -570,7 +565,6 @@ func TestDeleteManagedObjectStorageUserAccessKey(t *testing.T) {
 
 		_, err = svc.WaitForManagedObjectStorageUserOperationalState(context.Background(), &request.WaitForManagedObjectStorageUserOperationalStateRequest{
 			ServiceUUID:  storage.UUID,
-			Timeout:      time.Second * 90,
 			Username:     storage.Users[0].Username,
 			DesiredState: upcloud.ManagedObjectStorageUserOperationalStateReady,
 		})

--- a/upcloud/service/retry.go
+++ b/upcloud/service/retry.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"time"
+)
+
+type retryConfig struct {
+	interval time.Duration
+	// Inverse the should retry logic. By default, operation is retried until operation returns a value. If inverse is set to true, operation is retried while operation returns a value. This should be used, for example, for waiting until resource is deleted.
+	inverse bool
+}
+
+func fillDefaults(c *retryConfig) *retryConfig {
+	if c == nil {
+		c = &retryConfig{}
+	}
+
+	if c.interval.Milliseconds() == 0 {
+		c.interval = time.Second * 5
+	}
+
+	return c
+}
+
+func retry[T any](ctx context.Context, operation func(int, context.Context) (*T, error), config *retryConfig) (*T, error) {
+	config = fillDefaults(config)
+
+	ticker := time.NewTicker(config.interval)
+	defer ticker.Stop()
+
+	for i := 0; ; i++ {
+		select {
+		case <-ticker.C:
+			value, err := operation(i, ctx)
+			if err != nil {
+				return value, err
+			}
+			if !config.inverse && value != nil {
+				return value, nil
+			}
+			if config.inverse && value == nil {
+				return nil, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}

--- a/upcloud/service/retry_test.go
+++ b/upcloud/service/retry_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetry_noInverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.TODO()
+	value, err := retry(ctx, func(i int, _ context.Context) (*string, error) {
+		if i < 3 {
+			return nil, nil
+		}
+
+		value := "ready"
+		return &value, nil
+	}, &retryConfig{interval: time.Millisecond * 125})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ready", *value)
+}
+
+func TestRetry_timeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	value, err := retry(ctx, func(i int, _ context.Context) (*string, error) {
+		return nil, nil
+	}, &retryConfig{interval: time.Millisecond * 125})
+
+	assert.Error(t, err)
+	assert.Nil(t, value)
+}
+
+func TestRetry_inverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.TODO()
+	value, err := retry(ctx, func(i int, _ context.Context) (*int, error) {
+		if i < 3 {
+			return &i, nil
+		}
+		return nil, nil
+	}, &retryConfig{interval: time.Millisecond * 125, inverse: true})
+
+	assert.NoError(t, err)
+	assert.Nil(t, value)
+}
+
+func TestRetry_noInterval(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config *retryConfig
+	}{
+		{name: "no interval", config: &retryConfig{inverse: false}},
+		{name: "nil config", config: nil},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 125*time.Millisecond)
+			defer cancel()
+
+			value, err := retry(ctx, func(i int, _ context.Context) (*int, error) {
+				return &i, nil
+			}, test.config)
+
+			assert.Error(t, err)
+			assert.Nil(t, value)
+		})
+	}
+}

--- a/upcloud/service/server_test.go
+++ b/upcloud/service/server_test.go
@@ -544,7 +544,6 @@ func waitForServerState(ctx context.Context, rec *recorder.Recorder, svc *Servic
 	_, err := svc.WaitForServerState(ctx, &request.WaitForServerStateRequest{
 		UUID:         serverUUID,
 		DesiredState: desiredState,
-		Timeout:      waitTimeout,
 	})
 	if err != nil {
 		return err
@@ -574,7 +573,6 @@ func stopServerWithoutRecorder(ctx context.Context, svc *Service, uuid string) e
 	_, err = svc.WaitForServerState(ctx, &request.WaitForServerStateRequest{
 		UUID:         serverDetails.UUID,
 		DesiredState: upcloud.ServerStateStopped,
-		Timeout:      waitTimeout,
 	})
 
 	return err

--- a/upcloud/service/storage_test.go
+++ b/upcloud/service/storage_test.go
@@ -662,7 +662,6 @@ func waitForStorageImportCompletion(ctx context.Context, rec *recorder.Recorder,
 
 	_, err := svc.WaitForStorageImportCompletion(ctx, &request.WaitForStorageImportCompletionRequest{
 		StorageUUID: storageUUID,
-		Timeout:     15 * time.Minute,
 	})
 
 	return err
@@ -684,7 +683,6 @@ func waitForStorageOnlineState(ctx context.Context, rec *recorder.Recorder, svc 
 	_, err := svc.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
 		UUID:         storageUUID,
 		DesiredState: upcloud.StorageStateOnline,
-		Timeout:      waitTimeout,
 	})
 
 	return err

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -126,7 +126,6 @@ func teardown() {
 		serverDetails, err := svc.WaitForServerState(ctx, &request.WaitForServerStateRequest{
 			UUID:           server.UUID,
 			UndesiredState: upcloud.ServerStateMaintenance,
-			Timeout:        waitTimeout,
 		})
 		handleError(err)
 
@@ -157,7 +156,6 @@ func teardown() {
 			_, err = svc.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
 				UUID:         storage.UUID,
 				DesiredState: upcloud.StorageStateOnline,
-				Timeout:      waitTimeout,
 			})
 			handleError(err)
 		}


### PR DESCRIPTION
This is to remove duplicate timeouts: the `context.Context` parameter passed in to the `WaitFor*` methods might already have an timeout defined. Thus, the `Timeout` field might cause confusing errors when, for example, the timeout defined in `Timeout` field is shorter than timeout defined in the context passed in from e.g. Terraform.