### PR TITLE
chore(gateway): revert adding `Page` field to `GetGatewaysRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Added
-
-- Gateway: add paging support to `GetGateways` method.
-
 ## [8.2.0]
 
 ### Added

--- a/upcloud/request/gateway.go
+++ b/upcloud/request/gateway.go
@@ -10,21 +10,14 @@ const gatewayBaseURL string = "/gateway"
 
 type GetGatewaysRequest struct {
 	Filters []QueryFilter
-	Page    *Page
 }
 
 func (r *GetGatewaysRequest) RequestURL() string {
-	f := make([]QueryFilter, len(r.Filters))
-	copy(f, r.Filters)
-	if r.Page != nil {
-		f = append(f, r.Page)
-	}
-
-	if len(f) == 0 {
+	if len(r.Filters) == 0 {
 		return gatewayBaseURL
 	}
 
-	return fmt.Sprintf("%s?%s", gatewayBaseURL, encodeQueryFilters(f))
+	return fmt.Sprintf("%s?%s", gatewayBaseURL, encodeQueryFilters(r.Filters))
 }
 
 type GetGatewayRequest struct {

--- a/upcloud/request/gateway_test.go
+++ b/upcloud/request/gateway_test.go
@@ -13,35 +13,18 @@ func TestGetGatewaysRequest(t *testing.T) {
 	r := GetGatewaysRequest{}
 	assert.Equal(t, "/gateway", r.RequestURL())
 
-	filters := []QueryFilter{
-		FilterLabel{
-			Label: upcloud.Label{
-				Key:   "color",
-				Value: "green",
-			},
-		},
-		FilterLabelKey{Key: "size"},
-	}
-
 	r = GetGatewaysRequest{
-		Filters: filters,
+		Filters: []QueryFilter{
+			FilterLabel{
+				Label: upcloud.Label{
+					Key:   "color",
+					Value: "green",
+				},
+			},
+			FilterLabelKey{Key: "size"},
+		},
 	}
 	assert.Equal(t, "/gateway?label=color%3Dgreen&label=size", r.RequestURL())
-
-	page := &Page{
-		Size:   15,
-		Number: 3,
-	}
-	r = GetGatewaysRequest{
-		Page: page,
-	}
-	assert.Equal(t, "/gateway?limit=15&offset=30", r.RequestURL())
-
-	r = GetGatewaysRequest{
-		Filters: filters,
-		Page:    page,
-	}
-	assert.Equal(t, "/gateway?label=color%3Dgreen&label=size&limit=15&offset=30", r.RequestURL())
 }
 
 func TestGetGatewayRequest(t *testing.T) {


### PR DESCRIPTION
This reverts commit bb108795ee029e8cd3f3882fcb3e80a96fc4cf87. The `GetGateways` method already supports paging as `*Page` implements `QueryFilter` interface. Thus this change is not needed for now. This can be re-done later if we want to sync service methods so that all list methods take the related request struct as a parameter.