### PR TITLE
fix(storage): do not close local file while it is being imported

### DIFF
--- a/upcloud/service/storage.go
+++ b/upcloud/service/storage.go
@@ -169,7 +169,6 @@ func (s *Service) directStorageImport(ctx context.Context, r *request.CreateStor
 			return nil, fmt.Errorf("unable to open SourceLocation: %w", err)
 		}
 		bodyReader = f
-		defer f.Close()
 	case io.Reader:
 		bodyReader = v
 	default:


### PR DESCRIPTION
~~The file will be automatically closed by HTTP client, so closing it in the function that initiates the HTTP call will cause the storage import to fail.~~ (The request is done in a blocking call so deferred close should not be an issue)