### PR TITLE
chore: update Go, Actions dependencies and lint config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout head
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Get tag version
@@ -19,7 +19,7 @@ jobs:
         id: release_notes
         run: make release-notes > .release_notes
       - name: Run goreleaser-action
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest
           args: release --clean --release-notes=.release_notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         # support two latest major versions of Go, following the Go security policy
         # in which these versions get security updates. See https://golang.org/security
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/user-agent.yml
+++ b/.github/workflows/user-agent.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check version in User-Agent
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: ./scripts/update-user-agent-version.sh
       - uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,6 @@
-# Golang CI pipeline configuration
+version: "2"
 linters:
-  disable-all: true
-
-  # Run golangci-lint linters to see the list of all linters
-  # Please keep them sorted alphabetically
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -13,13 +10,9 @@ linters:
     - dogsled
     - errcheck
     - goconst
-    - gofumpt
-    - goimports
-    # - golint # TODO: upgrade to revive and re-enable, needs breaking change due to wanting IpAddress -> IPAddress
     - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -29,26 +22,44 @@ linters:
     - predeclared
     - rowserrcheck
     - staticcheck
-    # - stylecheck # TODO: re-enable, needs breaking change due to wanting IpAddress -> IPAddress
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
-
+  settings:
+    goconst:
+      min-len: 5
+    predeclared:
+      ignore:
+        - new
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - funlen
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  uniq-by-line: false
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - funlen
-        - bodyclose
-
-linters-settings:
-  goconst:
-    min-len: 5
-  predeclared:
-    ignore: "new"
+  uniq-by-line: false
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+- Go version bump to 1.23
+
 ## [8.18.0]
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-go-api/v8
 
-go 1.22
+go 1.23
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/upcloud/service/account_test.go
+++ b/upcloud/service/account_test.go
@@ -55,8 +55,8 @@ func TestListDetailsCreateModifyDeleteSubaccount(t *testing.T) {
 		rec.AddFilter(func(i *cassette.Interaction) error {
 			// try to mask username from recording just in case if developer forgets to review it before commit
 			testuser, _ := getCredentials()
-			i.Request.Body = strings.Replace(i.Request.Body, testuser, mainAccount, -1)
-			i.Response.Body = strings.Replace(i.Response.Body, testuser, mainAccount, -1)
+			i.Request.Body = strings.ReplaceAll(i.Request.Body, testuser, mainAccount)
+			i.Response.Body = strings.ReplaceAll(i.Response.Body, testuser, mainAccount)
 			return nil
 		})
 		username := "sdk_test_subaccount"

--- a/upcloud/service/utils_test.go
+++ b/upcloud/service/utils_test.go
@@ -107,7 +107,7 @@ func record(t *testing.T, fixture string, f func(context.Context, *testing.T, *r
 			}
 		}
 
-		if i.Request.Method == http.MethodPut && strings.Contains(i.Request.URL, "uploader") {
+		if i.Method == http.MethodPut && strings.Contains(i.URL, "uploader") {
 			// We will remove the body from the upload to reduce fixture size
 			i.Request.Body = ""
 		}


### PR DESCRIPTION
Changes:
- Update actions/checkout from v4.1.7 to v4.2.2
- Update actions/setup-go from v5.0.2 to v5.5.0
- Update golangci-lint-action from v6.1.0 to v8.0.0
- Update goreleaser-action from v5.1.0 to v6.3.0
- Modernize .golangci.yaml to use v2 configuration format
- Bump minimum Go version from 1.22 to 1.23
- Fix deprecated strings.Replace usage in tests

This ensures CI uses latest stable versions and follows current golangci-lint best practices for configuration.