### PR TITLE
feat(account): add billing summary

### DIFF
--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -187,3 +187,69 @@ func (a *AccountList) UnmarshalJSON(b []byte) error {
 	*a = append(*a, v.Accounts.Item...)
 	return nil
 }
+
+// BillingSummary represents billing summary for a specific month
+type BillingSummary struct {
+	Currency              string           `json:"currency"`
+	TotalAmount           float64          `json:"total_amount"`
+	Servers               *BillingCategory `json:"servers,omitempty"`
+	ManagedDatabases      *BillingCategory `json:"managed_databases,omitempty"`
+	ManagedObjectStorages *BillingCategory `json:"managed_object_storages,omitempty"`
+	ManagedLoadbalancers  *BillingCategory `json:"managed_loadbalancers,omitempty"`
+	ManagedKubernetes     *BillingCategory `json:"managed_kubernetes,omitempty"`
+	NetworkGateways       *BillingCategory `json:"network_gateways,omitempty"`
+}
+
+// BillingCategory represents a billing category with its resources
+type BillingCategory struct {
+	TotalAmount          float64               `json:"total_amount"`
+	Server               *BillingResourceGroup `json:"server,omitempty"`
+	ManagedDatabase      *BillingResourceGroup `json:"managed_database,omitempty"`
+	ManagedObjectStorage *BillingResourceGroup `json:"managed_object_storage,omitempty"`
+	ManagedLoadbalancer  *BillingResourceGroup `json:"managed_loadbalancers,omitempty"`
+	ManagedKubernetes    *BillingResourceGroup `json:"managed_kubernetes,omitempty"`
+	NetworkGateway       *BillingResourceGroup `json:"network_gateway,omitempty"`
+}
+
+// BillingResourceGroup represents a group of resources with their details
+type BillingResourceGroup struct {
+	Resources   []BillingResource `json:"resources"`
+	TotalAmount float64           `json:"total_amount"`
+}
+
+// BillingResource represents a billable resource
+type BillingResource struct {
+	ResourceID string                  `json:"resource_id"`
+	Amount     float64                 `json:"amount"`
+	Hours      int                     `json:"hours"`
+	Details    []BillingResourceDetail `json:"details"`
+}
+
+// BillingResourceDetail represents detailed billing information for a resource
+type BillingResourceDetail struct {
+	Amount          float64 `json:"amount"`
+	Hours           int     `json:"hours"`
+	Plan            string  `json:"plan,omitempty"`
+	Zone            string  `json:"zone,omitempty"`
+	Size            int     `json:"size,omitempty"`
+	Cores           int     `json:"cores,omitempty"`
+	Memory          int     `json:"memory,omitempty"`
+	Firewall        float64 `json:"firewall,omitempty"`
+	Licenses        float64 `json:"licenses,omitempty"`
+	SimpleBackup    float64 `json:"simple_backup,omitempty"`
+	BillableSizeGiB int     `json:"billable_size_gib,omitempty"`
+	Labels          []Label `json:"labels,omitempty"`
+}
+
+// UnmarshalJSON is a custom unmarshaller for BillingSummary
+func (b *BillingSummary) UnmarshalJSON(data []byte) error {
+	type localBillingSummary BillingSummary
+
+	v := struct {
+		*localBillingSummary
+	}{
+		localBillingSummary: (*localBillingSummary)(b),
+	}
+
+	return json.Unmarshal(data, &v)
+}

--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -198,6 +198,8 @@ type BillingSummary struct {
 	ManagedLoadbalancers  *BillingCategory `json:"managed_loadbalancers,omitempty"`
 	ManagedKubernetes     *BillingCategory `json:"managed_kubernetes,omitempty"`
 	NetworkGateways       *BillingCategory `json:"network_gateways,omitempty"`
+	Networks              *BillingCategory `json:"networks,omitempty"`
+	Storages              *BillingCategory `json:"storages,omitempty"`
 }
 
 // BillingCategory represents a billing category with its resources
@@ -209,6 +211,10 @@ type BillingCategory struct {
 	ManagedLoadbalancer  *BillingResourceGroup `json:"managed_loadbalancers,omitempty"`
 	ManagedKubernetes    *BillingResourceGroup `json:"managed_kubernetes,omitempty"`
 	NetworkGateway       *BillingResourceGroup `json:"network_gateway,omitempty"`
+	IPv4Address          *BillingResourceGroup `json:"ipv4_address,omitempty"`
+	Backup               *BillingResourceGroup `json:"backup,omitempty"`
+	Storage              *BillingResourceGroup `json:"storage,omitempty"`
+	Template             *BillingResourceGroup `json:"template,omitempty"`
 }
 
 // BillingResourceGroup represents a group of resources with their details

--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -246,16 +246,3 @@ type BillingResourceDetail struct {
 	BillableSizeGiB int     `json:"billable_size_gib,omitempty"`
 	Labels          []Label `json:"labels,omitempty"`
 }
-
-// UnmarshalJSON is a custom unmarshaller for BillingSummary
-func (b *BillingSummary) UnmarshalJSON(data []byte) error {
-	type localBillingSummary BillingSummary
-
-	v := struct {
-		*localBillingSummary
-	}{
-		localBillingSummary: (*localBillingSummary)(b),
-	}
-
-	return json.Unmarshal(data, &v)
-}

--- a/upcloud/request/account.go
+++ b/upcloud/request/account.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 )
@@ -109,4 +110,27 @@ type GetAccountDetailsRequest struct {
 // RequestURL implements the Request interface
 func (r *GetAccountDetailsRequest) RequestURL() string {
 	return fmt.Sprintf("/account/details/%s", r.Username)
+}
+
+// GetBillingSummaryRequest represents a request to get billing summary
+type GetBillingSummaryRequest struct {
+	// YearMonth in format YYYY-MM (e.g., "2024-09")
+	YearMonth string
+	// If specified, only the details of the given resource are returned.
+	ResourceID string
+	// If specified, retrieves the billing summary of given account instead of the calling account.
+	// Requires Partner API access and existing association between partner account and given account.
+	Username string
+}
+
+// RequestURL implements the Request interface
+func (r *GetBillingSummaryRequest) RequestURL() string {
+	qv := url.Values{}
+	if r.ResourceID != "" {
+		qv.Set("resource_id", r.ResourceID)
+	}
+	if r.Username != "" {
+		qv.Set("username", r.Username)
+	}
+	return fmt.Sprintf("/account/billing/summary/%s?%s", r.YearMonth, qv.Encode())
 }

--- a/upcloud/request/account_test.go
+++ b/upcloud/request/account_test.go
@@ -211,3 +211,18 @@ func TestModifySubaccountRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(actualJSON))
 }
+
+func TestCreateBillingSummaryRequest(t *testing.T) {
+	r := GetBillingSummaryRequest{
+		YearMonth:  "2025-05",
+		ResourceID: "123-123-123",
+		Username:   "mock-username",
+	}
+	expectedURL := "/account/billing/summary/2025-05?resource_id=123-123-123&username=mock-username"
+	assert.Equal(t, expectedURL, r.RequestURL())
+	r = GetBillingSummaryRequest{
+		YearMonth: "2025-05",
+	}
+	expectedURL = "/account/billing/summary/2025-05?"
+	assert.Equal(t, expectedURL, r.RequestURL())
+}

--- a/upcloud/service/account.go
+++ b/upcloud/service/account.go
@@ -14,6 +14,7 @@ type Account interface {
 	CreateSubaccount(ctx context.Context, r *request.CreateSubaccountRequest) (*upcloud.AccountDetails, error)
 	ModifySubaccount(ctx context.Context, r *request.ModifySubaccountRequest) (*upcloud.AccountDetails, error)
 	DeleteSubaccount(ctx context.Context, r *request.DeleteSubaccountRequest) error
+	GetBillingSummary(ctx context.Context, r *request.GetBillingSummaryRequest) (*upcloud.BillingSummary, error)
 }
 
 // GetAccount returns the current user's account
@@ -53,4 +54,10 @@ func (s *Service) CreateSubaccount(ctx context.Context, r *request.CreateSubacco
 // DeleteSubaccount deletes a sub account
 func (s *Service) DeleteSubaccount(ctx context.Context, r *request.DeleteSubaccountRequest) error {
 	return s.delete(ctx, r)
+}
+
+// GetBillingSummary returns billing summary for the specified month
+func (s *Service) GetBillingSummary(ctx context.Context, r *request.GetBillingSummaryRequest) (*upcloud.BillingSummary, error) {
+	billingSummary := upcloud.BillingSummary{}
+	return &billingSummary, s.get(ctx, r.RequestURL(), &billingSummary)
 }


### PR DESCRIPTION
This PR adds billing summary support to the account service.
Follows the API /account/billing/summary/{year-month} endpoint as documented in the account section.

Notes:

-  The `BillingCategory` and `BillingResourceGroup` structs handle the nested JSON structure where categories contain both a total_amount and a nested object (e.g., servers.server, managed_databases.managed_database). If there is a better approach, let me know.
- Some billing categories like `storages` and `networks` are not included as they require specific API response examples. If you can provide with that details, I can implement.