### PR TITLE
feat: add GPUs to resource limits and server plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- account: add GPUs to resource limits
+- server: add GPUs to server plans
+
 ## [8.22.0]
 
 ### Added

--- a/upcloud/account.go
+++ b/upcloud/account.go
@@ -33,6 +33,7 @@ type ResourceLimits struct {
 	StorageMaxIOPS        int `json:"storage_maxiops,omitempty"`
 	StorageSSD            int `json:"storage_ssd,omitempty"`
 	LoadBalancers         int `json:"load_balancers,omitempty"`
+	GPUs                  int `json:"gpus,omitempty"`
 }
 
 // UnmarshalJSON is a custom unmarshaller that deals with

--- a/upcloud/account_test.go
+++ b/upcloud/account_test.go
@@ -27,7 +27,8 @@ func TestUnmarshalAccount(t *testing.T) {
 			"storage_hdd": 10240,
 			"storage_maxiops": 10240,
 			"storage_ssd": 10240,
-			"load_balancers": 50
+			"load_balancers": 50,
+			"gpus": 8
 		  }
 		}
 	  }
@@ -51,6 +52,7 @@ func TestUnmarshalAccount(t *testing.T) {
 	assert.Equal(t, 10240, account.ResourceLimits.StorageMaxIOPS)
 	assert.Equal(t, 10240, account.ResourceLimits.StorageSSD)
 	assert.Equal(t, 50, account.ResourceLimits.LoadBalancers)
+	assert.Equal(t, 8, account.ResourceLimits.GPUs)
 }
 
 // TestMarshalAccount tests that Account objects marshal correctly

--- a/upcloud/plan.go
+++ b/upcloud/plan.go
@@ -35,4 +35,6 @@ type Plan struct {
 	PublicTrafficOut int    `json:"public_traffic_out"`
 	StorageSize      int    `json:"storage_size"`
 	StorageTier      string `json:"storage_tier"`
+	GPUAmount        int    `json:"gpu_amount"`
+	GPUModel         string `json:"gpu_model"`
 }

--- a/upcloud/plan_test.go
+++ b/upcloud/plan_test.go
@@ -28,6 +28,16 @@ func TestUnmarshalPlans(t *testing.T) {
               "public_traffic_out" : 4096,
               "storage_size" : 80,
               "storage_tier" : "maxiops"
+            },
+            {
+              "core_number" : 8,
+              "gpu_amount" : 1,
+              "gpu_model" : "NVIDIA L40S",
+              "memory_amount" : 65536,
+              "name" : "GPU-8xCPU-64GB-1xL40S",
+              "public_traffic_out" : 12,
+              "storage_size" : 0,
+              "storage_tier" : null
             }
           ]
         }
@@ -37,7 +47,7 @@ func TestUnmarshalPlans(t *testing.T) {
 	plans := Plans{}
 	err := json.Unmarshal([]byte(originalJSON), &plans)
 	assert.Nil(t, err)
-	assert.Len(t, plans.Plans, 2)
+	assert.Len(t, plans.Plans, 3)
 
 	testData := []Plan{
 		{
@@ -47,6 +57,8 @@ func TestUnmarshalPlans(t *testing.T) {
 			PublicTrafficOut: 2048,
 			StorageSize:      50,
 			StorageTier:      "maxiops",
+			GPUAmount:        0,
+			GPUModel:         "",
 		},
 		{
 			CoreNumber:       2,
@@ -55,6 +67,18 @@ func TestUnmarshalPlans(t *testing.T) {
 			PublicTrafficOut: 4096,
 			StorageSize:      80,
 			StorageTier:      "maxiops",
+			GPUAmount:        0,
+			GPUModel:         "",
+		},
+		{
+			CoreNumber:       8,
+			MemoryAmount:     65536,
+			Name:             "GPU-8xCPU-64GB-1xL40S",
+			PublicTrafficOut: 12,
+			StorageSize:      0,
+			StorageTier:      "",
+			GPUAmount:        1,
+			GPUModel:         "NVIDIA L40S",
 		},
 	}
 
@@ -66,5 +90,7 @@ func TestUnmarshalPlans(t *testing.T) {
 		assert.Equal(t, p.PublicTrafficOut, plan.PublicTrafficOut)
 		assert.Equal(t, p.StorageSize, plan.StorageSize)
 		assert.Equal(t, p.StorageTier, plan.StorageTier)
+		assert.Equal(t, p.GPUAmount, plan.GPUAmount)
+		assert.Equal(t, p.GPUModel, plan.GPUModel)
 	}
 }

--- a/upcloud/service/account_test.go
+++ b/upcloud/service/account_test.go
@@ -38,6 +38,7 @@ func TestGetAccount(t *testing.T) {
 	assert.NotZero(t, account.ResourceLimits.PublicIPv6)
 	assert.NotZero(t, account.ResourceLimits.StorageHDD)
 	assert.NotZero(t, account.ResourceLimits.StorageSSD)
+	assert.GreaterOrEqual(t, account.ResourceLimits.GPUs, 0)
 }
 
 // TestListDetailsCreateModifyDeleteSubaccountContext tests that subaccount functionality works correctly with context.


### PR DESCRIPTION
- Add GPUs field to ResourceLimits struct for account resource limits
- Add GPUAmount and GPUModel fields to Plan struct for server plans
- Update tests to include GPU field validation