### PR TITLE
chore(deps): bump Go version to v1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # support two latest major versions of Go, following the Go security policy
         # in which these versions get security updates. See https://golang.org/security
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+- Go version bump to 1.24
+
 ## [8.25.0]
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-go-api/v8
 
-go 1.23
+go 1.24
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
As per [Go release policy](https://go.dev/doc/devel/release#policy), Go 1.23 is no longer supported.