### PR TITLE
chore(ci): dependabot for credentials module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: gomod
+    directory: /credentials
+    commit-message:
+      prefix: "deps(credentials)"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Configure Dependabot to monitor Go dependencies for the `credentials` package` located in the `/credentials` directory as a separate Go mod.