### PR TITLE
chore(ci): remove extra commit prefix from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,5 @@ updates:
       interval: daily
   - package-ecosystem: gomod
     directory: /credentials
-    commit-message:
-      prefix: "deps(credentials)"
     schedule:
       interval: daily


### PR DESCRIPTION
Looks like the scope is already in the title as shown in #404. Maybe `chore` is a better type anyway. 