### PR TITLE
chore(net dhcp): convert to pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
-- ExcludeBySource, FilterByDestination and FilterByRouteType in EffectiveRoutesAutoPopulation struct change to pointers.
+- network: ExcludeBySource, FilterByDestination and FilterByRouteType in EffectiveRoutesAutoPopulation struct changed to pointers
 
 ## [8.27.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - database: add GetAllManagedDatabases to retrieve all managed databases regardless of paging
-- network: add support for DHCP Routes Configuration and Effective Routes Auto Population
+
+### Changed
+
+- network: ExcludeBySource, FilterByDestination and FilterByRouteType in EffectiveRoutesAutoPopulation struct changed to pointers
 
 ## [8.27.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- ExcludeBySource, FilterByDestination and FilterByRouteType in EffectiveRoutesAutoPopulation struct change to pointers.
+
 ## [8.27.0]
 
 ### Added

--- a/upcloud/network.go
+++ b/upcloud/network.go
@@ -104,10 +104,10 @@ type DHCPRoutesConfiguration struct {
 }
 
 type EffectiveRoutesAutoPopulation struct {
-	Enabled             Boolean              `json:"enabled"`
-	ExcludeBySource     []NetworkRouteSource `json:"exclude_by_source,omitempty"`
-	FilterByDestination []string             `json:"filter_by_destination,omitempty"`
-	FilterByRouteType   []NetworkRouteType   `json:"filter_by_route_type,omitempty"`
+	Enabled             Boolean               `json:"enabled"`
+	ExcludeBySource     *[]NetworkRouteSource `json:"exclude_by_source,omitempty"`
+	FilterByDestination *[]string             `json:"filter_by_destination,omitempty"`
+	FilterByRouteType   *[]NetworkRouteType   `json:"filter_by_route_type,omitempty"`
 }
 
 // IPNetwork represents an IP network in a response.

--- a/upcloud/request/network_test.go
+++ b/upcloud/request/network_test.go
@@ -87,9 +87,9 @@ func TestMarshalCreateNetworkRequest(t *testing.T) {
 				DHCPRoutesConfiguration: upcloud.DHCPRoutesConfiguration{
 					EffectiveRoutesAutoPopulation: upcloud.EffectiveRoutesAutoPopulation{
 						Enabled:             upcloud.True,
-						ExcludeBySource:     []upcloud.NetworkRouteSource{"static-route"},
-						FilterByDestination: []string{"172.16.0.0/22"},
-						FilterByRouteType:   []upcloud.NetworkRouteType{"service"},
+						ExcludeBySource:     &[]upcloud.NetworkRouteSource{"static-route"},
+						FilterByDestination: &[]string{"172.16.0.0/22"},
+						FilterByRouteType:   &[]upcloud.NetworkRouteType{"service"},
 					},
 				},
 			},

--- a/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
+++ b/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
@@ -12,19 +12,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
+      - upcloud-go-api/8.27.0
     url: https://api.upcloud.com/1.3/network/
     method: POST
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"0319cad1-e085-4c6f-a446-33f262d9004f","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "859"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:56:31 GMT
+      - Mon, 15 Sep 2025 11:33:42 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -33,7 +33,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"0319cad1-e085-4c6f-a446-33f262d9004f"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"036500e8-2935-45f7-b9b2-506859c5e18c"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
     form: {}
     headers:
       Accept:
@@ -43,18 +43,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
+      - upcloud-go-api/8.27.0
     url: https://api.upcloud.com/1.3/server
     method: POST
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1756889792,"devices":{"device":[]},"firewall":"off","host":8556659331,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.0.216","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:618d","family":"IPv6"},{"access":"public","address":"85.9.221.151","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.0.216","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e6:63","network":"03652712-70ca-49d6-bd6d-f321d10b9b53","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.221.151","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:6d:f0","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:618d","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:61:8d","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:dd:5c","network":"0319cad1-e085-4c6f-a446-33f262d9004f","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"h8d89s525j52xm78","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"tn77A4Tk","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"017f8e7d-806b-4802-905c-2d00d2bb3525","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"00339795-955e-42aa-b742-0c3fbf14b486","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1757936023,"devices":{"device":[]},"firewall":"off","host":5738087043,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.19","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","family":"IPv6"},{"access":"public","address":"94.237.8.118","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.19","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e1:8f","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.8.118","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:01:a8","network":"03000000-0000-4000-8044-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:35:ef","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:b1:5d","network":"036500e8-2935-45f7-b9b2-506859c5e18c","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"q8626gdt9jv6bz86","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"7Q7tp4Vd","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01e77c5b-97ad-4321-9a62-2ea0bb71fad2","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "6226"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:56:32 GMT
+      - Mon, 15 Sep 2025 11:33:43 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -73,18 +73,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
-    url: https://api.upcloud.com/1.3/server/00339795-955e-42aa-b742-0c3fbf14b486
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/server/00785261-8484-48c5-a8bc-f58ce766fdd2
     method: GET
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1756889792,"devices":{"device":[]},"firewall":"off","host":8556659331,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.0.216","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:618d","family":"IPv6"},{"access":"public","address":"85.9.221.151","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.0.216","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e6:63","network":"03652712-70ca-49d6-bd6d-f321d10b9b53","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.221.151","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:6d:f0","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:618d","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:61:8d","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:dd:5c","network":"0319cad1-e085-4c6f-a446-33f262d9004f","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"tn77A4Tk","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"017f8e7d-806b-4802-905c-2d00d2bb3525","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00339795-955e-42aa-b742-0c3fbf14b486","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1757936023,"devices":{"device":[]},"firewall":"off","host":5738087043,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.19","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","family":"IPv6"},{"access":"public","address":"94.237.8.118","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.19","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e1:8f","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.8.118","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:01:a8","network":"03000000-0000-4000-8044-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:35:ef","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:b1:5d","network":"036500e8-2935-45f7-b9b2-506859c5e18c","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"7Q7tp4Vd","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01e77c5b-97ad-4321-9a62-2ea0bb71fad2","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "6132"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:58:25 GMT
+      - Mon, 15 Sep 2025 11:34:31 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -103,19 +103,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
-    url: https://api.upcloud.com/1.3/network/0319cad1-e085-4c6f-a446-33f262d9004f
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00339795-955e-42aa-b742-0c3fbf14b486"}]},"type":"private","uuid":"0319cad1-e085-4c6f-a446-33f262d9004f","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2"}]},"type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1102"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:58:25 GMT
+      - Mon, 15 Sep 2025 11:34:31 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -134,19 +134,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
-    url: https://api.upcloud.com/1.3/network/0319cad1-e085-4c6f-a446-33f262d9004f
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
     method: PUT
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"0319cad1-e085-4c6f-a446-33f262d9004f","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1187"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:58:26 GMT
+      - Mon, 15 Sep 2025 11:34:32 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -165,19 +165,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - upcloud-go-api/8.25.0
-    url: https://api.upcloud.com/1.3/network/0319cad1-e085-4c6f-a446-33f262d9004f
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00339795-955e-42aa-b742-0c3fbf14b486"}]},"type":"private","uuid":"0319cad1-e085-4c6f-a446-33f262d9004f","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2"}]},"type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1430"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 03 Sep 2025 08:58:27 GMT
+      - Mon, 15 Sep 2025 11:34:33 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
+++ b/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
@@ -17,14 +17,14 @@ interactions:
     method: POST
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "859"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:22:24 GMT
+      - Wed, 17 Sep 2025 09:42:13 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -33,7 +33,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"03a30756-eac1-42dc-857e-27def01f8d72"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
     form: {}
     headers:
       Accept:
@@ -47,14 +47,14 @@ interactions:
     url: https://api.upcloud.com/1.3/server
     method: POST
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758097346,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.157","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","family":"IPv6"},{"access":"public","address":"85.9.220.234","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.157","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:8e:5e","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.220.234","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:62:35","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:31:a9","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:fb:e4","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"2e7985685wp39274","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"eYy74Yk9","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01ca2852-ccba-4bc7-a33d-23fd224c8e6a","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758102135,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.7.148","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","family":"IPv6"},{"access":"public","address":"94.237.12.210","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.7.148","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:97:77","network":"03692429-67a5-4227-b08b-60d9085754d7","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.12.210","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:73:8d","network":"03000000-0000-4000-8095-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:04:dd","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:f6:5f","network":"03a30756-eac1-42dc-857e-27def01f8d72","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"tb6uunb64bmr9s3a","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"7kFg66fY","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01d0b956-725d-4fd4-ade5-a5d0bf260d14","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "6228"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:22:25 GMT
+      - Wed, 17 Sep 2025 09:42:15 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -74,17 +74,17 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/server/0077f25c-df6c-4ec3-baff-60139e07b0b0
+    url: https://api.upcloud.com/1.3/server/00f53904-3f10-49cb-8c9c-103016ea7cbc
     method: GET
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758097346,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.157","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","family":"IPv6"},{"access":"public","address":"85.9.220.234","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.157","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:8e:5e","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.220.234","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:62:35","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:31:a9","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:fb:e4","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"eYy74Yk9","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01ca2852-ccba-4bc7-a33d-23fd224c8e6a","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758102135,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.7.148","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","family":"IPv6"},{"access":"public","address":"94.237.12.210","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.7.148","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:97:77","network":"03692429-67a5-4227-b08b-60d9085754d7","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.12.210","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:73:8d","network":"03000000-0000-4000-8095-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:04:dd","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:f6:5f","network":"03a30756-eac1-42dc-857e-27def01f8d72","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"7kFg66fY","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01d0b956-725d-4fd4-ade5-a5d0bf260d14","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "6134"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:54 GMT
+      - Wed, 17 Sep 2025 09:44:28 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -104,18 +104,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc"}]},"type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1102"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:54 GMT
+      - Wed, 17 Sep 2025 09:44:28 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -135,18 +135,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
     method: PUT
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1187"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:54 GMT
+      - Wed, 17 Sep 2025 09:44:29 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -166,18 +166,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc"}]},"type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1430"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:55 GMT
+      - Wed, 17 Sep 2025 09:44:29 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -197,18 +197,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
     method: PUT
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1074"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:55 GMT
+      - Wed, 17 Sep 2025 09:44:30 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -228,22 +228,104 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc"}]},"type":"private","uuid":"03a30756-eac1-42dc-857e-27def01f8d72","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1317"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 17 Sep 2025 08:23:56 GMT
+      - Wed, 17 Sep 2025 09:44:31 GMT
       Server:
       - Apache
       Strict-Transport-Security:
       - max-age=63072000
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"stop_server":{"stop_type":"hard","timeout":"900"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic [REDACTED]
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/server/00f53904-3f10-49cb-8c9c-103016ea7cbc/stop
+    method: POST
+  response:
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758102135,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.7.148","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","family":"IPv6"},{"access":"public","address":"94.237.12.210","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.7.148","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:97:77","network":"03692429-67a5-4227-b08b-60d9085754d7","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.12.210","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:73:8d","network":"03000000-0000-4000-8095-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:04dd","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:04:dd","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:f6:5f","network":"03a30756-eac1-42dc-857e-27def01f8d72","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"7kFg66fY","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01d0b956-725d-4fd4-ade5-a5d0bf260d14","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00f53904-3f10-49cb-8c9c-103016ea7cbc","video_model":"cirrus","zone":"fi-hel2"}}'
+    headers:
+      Content-Length:
+      - "6134"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 17 Sep 2025 09:44:31 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic [REDACTED]
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/server/00f53904-3f10-49cb-8c9c-103016ea7cbc/?storages=1
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 17 Sep 2025 09:44:57 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic [REDACTED]
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/03a30756-eac1-42dc-857e-27def01f8d72
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Wed, 17 Sep 2025 09:44:57 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
+++ b/upcloud/service/fixtures/dhcpnetworkconfigurations.yaml
@@ -17,14 +17,14 @@ interactions:
     method: POST
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "859"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:33:42 GMT
+      - Wed, 17 Sep 2025 08:22:24 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -33,7 +33,7 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"036500e8-2935-45f7-b9b2-506859c5e18c"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
+    body: '{"server":{"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"metadata":"no","networking":{"interfaces":{"interface":[{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"utility"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv6"}]},"type":"public"},{"ip_addresses":{"ip_address":[{"family":"IPv4"}]},"type":"private","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540"}]}},"password_delivery":"none","storage_devices":{"storage_device":[{"action":"clone","storage":"01000000-0000-4000-8000-000020060100","title":"disk1","size":10,"tier":"maxiops"}]},"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","remote_access_enabled":"no","zone":"fi-hel2"}}'
     form: {}
     headers:
       Accept:
@@ -47,14 +47,14 @@ interactions:
     url: https://api.upcloud.com/1.3/server
     method: POST
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1757936023,"devices":{"device":[]},"firewall":"off","host":5738087043,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.19","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","family":"IPv6"},{"access":"public","address":"94.237.8.118","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.19","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e1:8f","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.8.118","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:01:a8","network":"03000000-0000-4000-8044-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:35:ef","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:b1:5d","network":"036500e8-2935-45f7-b9b2-506859c5e18c","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"q8626gdt9jv6bz86","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"7Q7tp4Vd","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01e77c5b-97ad-4321-9a62-2ea0bb71fad2","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758097346,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.157","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","family":"IPv6"},{"access":"public","address":"85.9.220.234","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.157","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:8e:5e","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.220.234","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:62:35","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:31:a9","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:fb:e4","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","password":"2e7985685wp39274","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","progress":"0","remote_access_enabled":"no","remote_access_password":"eYy74Yk9","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"maintenance","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01ca2852-ccba-4bc7-a33d-23fd224c8e6a","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","username":"root","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
-      - "6226"
+      - "6228"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:33:43 GMT
+      - Wed, 17 Sep 2025 08:22:25 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -74,17 +74,17 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/server/00785261-8484-48c5-a8bc-f58ce766fdd2
+    url: https://api.upcloud.com/1.3/server/0077f25c-df6c-4ec3-baff-60139e07b0b0
     method: GET
   response:
-    body: '{"server":{"boot_order":"disk","core_number":"1","created":1757936023,"devices":{"device":[]},"firewall":"off","host":5738087043,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.19","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","family":"IPv6"},{"access":"public","address":"94.237.8.118","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.19","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:e1:8f","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"94.237.8.118","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:01:a8","network":"03000000-0000-4000-8044-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:35ef","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:35:ef","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:b1:5d","network":"036500e8-2935-45f7-b9b2-506859c5e18c","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"7Q7tp4Vd","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01e77c5b-97ad-4321-9a62-2ea0bb71fad2","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2","video_model":"cirrus","zone":"fi-hel2"}}'
+    body: '{"server":{"boot_order":"disk","core_number":"1","created":1758097346,"devices":{"device":[]},"firewall":"off","host":5872304771,"hostname":"uploud-go-sdk-integration-test-testcreatenetworkandserverdhcp.example.com","ip_addresses":{"ip_address":[{"access":"utility","address":"10.6.10.157","family":"IPv4"},{"access":"public","address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","family":"IPv6"},{"access":"public","address":"85.9.220.234","family":"IPv4"}]},"labels":{"label":[{"key":"managedBy","value":"upcloud-sdk-integration-test"},{"key":"testName","value":"TestCreateNetworkAndServerDHCP"}]},"license":0,"memory_amount":"1024","metadata":"no","networking":{"interfaces":{"interface":[{"bootable":"no","index":1,"ip_addresses":{"ip_address":[{"address":"10.6.10.157","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:8e:5e","network":"035a3774-c700-4a42-9e7d-38de3f817e3f","source_ip_filtering":"yes","type":"utility"},{"bootable":"no","index":2,"ip_addresses":{"ip_address":[{"address":"85.9.220.234","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:62:35","network":"03a46c59-c94d-4ffd-a95e-2373b5bf6f06","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":3,"ip_addresses":{"ip_address":[{"address":"2a04:3545:1000:720:6c28:ffff:fe12:31a9","dhcp_provided":"yes","family":"IPv6","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:31:a9","network":"03000000-0000-4000-8046-000000000000","source_ip_filtering":"yes","type":"public"},{"bootable":"no","index":4,"ip_addresses":{"ip_address":[{"address":"172.16.0.2","dhcp_provided":"yes","family":"IPv4","floating":"no","release_policy":"release"}]},"mac":"6e:28:ff:12:fb:e4","network":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","source_ip_filtering":"yes","type":"private"}]}},"nic_model":"virtio","plan":"custom","plan_ipv4_bytes":"0","plan_ipv6_bytes":"0","remote_access_enabled":"no","remote_access_password":"eYy74Yk9","remote_access_type":"vnc","server_group":null,"simple_backup":"no","state":"started","storage_devices":{"storage_device":[{"address":"virtio:0","boot_disk":"0","labels":[{"key":"_os_architecture","value":"64"},{"key":"_os_brand_name","value":"Debian"},{"key":"_os_brand_version","value":"11"},{"key":"_os_main_category","value":"Linux"},{"key":"_os_type","value":"debian"},{"key":"_template_uuid","value":"01000000-0000-4000-8000-000020060100"}],"storage":"01ca2852-ccba-4bc7-a33d-23fd224c8e6a","storage_encrypted":"no","storage_size":10,"storage_tier":"maxiops","storage_title":"disk1","type":"disk"}]},"tags":{"tag":[]},"timezone":"UTC","title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0","video_model":"cirrus","zone":"fi-hel2"}}'
     headers:
       Content-Length:
-      - "6132"
+      - "6134"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:34:31 GMT
+      - Wed, 17 Sep 2025 08:23:54 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -104,18 +104,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
+    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"no"}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2"}]},"type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1102"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:34:31 GMT
+      - Wed, 17 Sep 2025 08:23:54 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -135,18 +135,18 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
+    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
     method: PUT
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
+      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1187"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:34:32 GMT
+      - Wed, 17 Sep 2025 08:23:54 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -166,18 +166,80 @@ interactions:
       - application/json
       User-Agent:
       - upcloud-go-api/8.27.0
-    url: https://api.upcloud.com/1.3/network/036500e8-2935-45f7-b9b2-506859c5e18c
+    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
     method: GET
   response:
     body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":["172.16.0.0/22"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
-      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"00785261-8484-48c5-a8bc-f58ce766fdd2"}]},"type":"private","uuid":"036500e8-2935-45f7-b9b2-506859c5e18c","zone":"fi-hel2"}}'
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
     headers:
       Content-Length:
       - "1430"
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 15 Sep 2025 11:34:33 GMT
+      - Wed, 17 Sep 2025 08:23:55 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"network":{"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"family":"IPv4","gateway":"172.16.0.1","dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_destination":[]}}}]}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic [REDACTED]
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    method: PUT
+  response:
+    body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
+      default-route yes","type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+    headers:
+      Content-Length:
+      - "1074"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 17 Sep 2025 08:23:55 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic [REDACTED]
+      Content-Type:
+      - application/json
+      User-Agent:
+      - upcloud-go-api/8.27.0
+    url: https://api.upcloud.com/1.3/network/0353efbb-bdb0-44a8-a69f-c1b69d5fb540
+    method: GET
+  response:
+    body: '{"network":{"effective_routes":[],"ip_networks":{"ip_network":[{"address":"172.16.0.0/22","dhcp":"yes","dhcp_default_route":"yes","dhcp_dns":["172.16.0.10","172.16.1.10"],"dhcp_effective_routes":[],"dhcp_routes_configuration":{"effective_routes_auto_population":{"enabled":"yes","exclude_by_source":["static-route"],"filter_by_route_type":["service"]}},"family":"IPv4","gateway":"172.16.0.1"}]},"labels":[],"name":"sdk-test
+      default-route yes","servers":{"server":[{"title":"uploud-go-sdk-integration-test-TestCreateNetworkAndServerDHCP","uuid":"0077f25c-df6c-4ec3-baff-60139e07b0b0"}]},"type":"private","uuid":"0353efbb-bdb0-44a8-a69f-c1b69d5fb540","zone":"fi-hel2"}}'
+    headers:
+      Content-Length:
+      - "1317"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 17 Sep 2025 08:23:56 GMT
       Server:
       - Apache
       Strict-Transport-Security:

--- a/upcloud/service/network_test.go
+++ b/upcloud/service/network_test.go
@@ -830,6 +830,25 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.ExcludeBySource,
 			)
 		})
+		// Stop the server
+		t.Logf("Stopping server with UUID %s ...", srv.UUID)
+		err = stopServer(ctx, rec, svc, srv.UUID)
+		require.NoError(t, err)
+		t.Log("Server is now stopped")
+
+		// Delete the server and storage
+		t.Logf("Deleting the server with UUID %s, including storages...", srv.UUID)
+		err = deleteServerAndStorages(ctx, svc, srv.UUID)
+		require.NoError(t, err)
+		t.Log("Server is now deleted")
+
+		// Delete the network
+		t.Logf("Deleting the network with UUID %s...", network.UUID)
+		err = svc.DeleteNetwork(ctx, &request.DeleteNetworkRequest{
+			UUID: network.UUID,
+		})
+		require.NoError(t, err)
+		t.Log("Network is now deleted")
 
 		t.Run("DHCP_AutoPopulation_Unset_Filters", func(t *testing.T) {
 			modReq := &request.ModifyNetworkRequest{

--- a/upcloud/service/network_test.go
+++ b/upcloud/service/network_test.go
@@ -830,25 +830,6 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.ExcludeBySource,
 			)
 		})
-		// Stop the server
-		t.Logf("Stopping server with UUID %s ...", srv.UUID)
-		err = stopServer(ctx, rec, svc, srv.UUID)
-		require.NoError(t, err)
-		t.Log("Server is now stopped")
-
-		// Delete the server and storage
-		t.Logf("Deleting the server with UUID %s, including storages...", srv.UUID)
-		err = deleteServerAndStorages(ctx, svc, srv.UUID)
-		require.NoError(t, err)
-		t.Log("Server is now deleted")
-
-		// Delete the network
-		t.Logf("Deleting the network with UUID %s...", network.UUID)
-		err = svc.DeleteNetwork(ctx, &request.DeleteNetworkRequest{
-			UUID: network.UUID,
-		})
-		require.NoError(t, err)
-		t.Log("Network is now deleted")
 
 		t.Run("DHCP_AutoPopulation_Unset_Filters", func(t *testing.T) {
 			modReq := &request.ModifyNetworkRequest{
@@ -897,6 +878,26 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.ExcludeBySource,
 			)
 		})
+
+		// Stop the server
+		t.Logf("Stopping server with UUID %s ...", srv.UUID)
+		err = stopServer(ctx, rec, svc, srv.UUID)
+		require.NoError(t, err)
+		t.Log("Server is now stopped")
+
+		// Delete the server and storage
+		t.Logf("Deleting the server with UUID %s, including storages...", srv.UUID)
+		err = deleteServerAndStorages(ctx, svc, srv.UUID)
+		require.NoError(t, err)
+		t.Log("Server is now deleted")
+
+		// Delete the network
+		t.Logf("Deleting the network with UUID %s...", network.UUID)
+		err = svc.DeleteNetwork(ctx, &request.DeleteNetworkRequest{
+			UUID: network.UUID,
+		})
+		require.NoError(t, err)
+		t.Log("Network is now deleted")
 	})
 }
 

--- a/upcloud/service/network_test.go
+++ b/upcloud/service/network_test.go
@@ -779,7 +779,7 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 		}
 		assert.True(t, found, "server should be attached to created network")
 
-		t.Run("DHCP_AutoPopulation_AllFileters", func(t *testing.T) {
+		t.Run("DHCP_AutoPopulation_AllFilters", func(t *testing.T) {
 			modReq := &request.ModifyNetworkRequest{
 				UUID: network.UUID,
 				IPNetworks: []upcloud.IPNetwork{
@@ -793,9 +793,9 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 						DHCPRoutesConfiguration: upcloud.DHCPRoutesConfiguration{
 							EffectiveRoutesAutoPopulation: upcloud.EffectiveRoutesAutoPopulation{
 								Enabled:             upcloud.True,
-								FilterByDestination: []string{"172.16.0.0/22"},
-								FilterByRouteType:   []upcloud.NetworkRouteType{"service"},
-								ExcludeBySource:     []upcloud.NetworkRouteSource{"static-route"},
+								FilterByDestination: &[]string{"172.16.0.0/22"},
+								FilterByRouteType:   &[]upcloud.NetworkRouteType{"service"},
+								ExcludeBySource:     &[]upcloud.NetworkRouteSource{"static-route"},
 							},
 						},
 					},
@@ -817,17 +817,17 @@ func TestCreateNetworkAndServer_DHCPOptions(t *testing.T) {
 
 			assert.ElementsMatch(t,
 				[]string{"172.16.0.0/22"},
-				ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.FilterByDestination,
+				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.FilterByDestination,
 			)
 
 			assert.ElementsMatch(t,
 				[]upcloud.NetworkRouteType{"service"},
-				ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.FilterByRouteType,
+				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.FilterByRouteType,
 			)
 
 			assert.ElementsMatch(t,
 				[]upcloud.NetworkRouteSource{"static-route"},
-				ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.ExcludeBySource,
+				*ipNet.DHCPRoutesConfiguration.EffectiveRoutesAutoPopulation.ExcludeBySource,
 			)
 		})
 	})


### PR DESCRIPTION
This is needed to be able to clean dhcp filters from the terraform provider. 
nil pointer array -> not specified, keep what you have
pointer to empty array -> clean the values
pointer to array -> Set the values