### PR TITLE
fix(lbaas): add field for clearing backend props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- load-balancer: Add workaround for clearing backend properties in `ModifyLoadBalancerBackendRequest`.
+
 ## [8.29.1]
 
 ### Changed


### PR DESCRIPTION
Alternative would be to modify `upcloud.LoadBalancerBackendProperties` to use pointer types for these two fields, but that would be a breaking change (and we use separate types for requests and responses for some resources). Thus, I would go with this workaround for now and fix the types in next major release.