### PR TITLE
feat(file-storage): add encrypted field to FileStorage and CreateFileStorageRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- file-storage: add `Encrypted` field to `request.CreateFileStorageRequest` and `upcloud.FileStorage` structs.
+
 ## [8.36.1]
 
 ### Fixed

--- a/upcloud/file_storage.go
+++ b/upcloud/file_storage.go
@@ -26,6 +26,7 @@ type FileStorage struct {
 	UUID             string                      `json:"uuid"`
 	Name             string                      `json:"name"`
 	Zone             string                      `json:"zone"`
+	Encrypted        bool                        `json:"encrypted"`
 	ConfiguredStatus FileStorageConfiguredStatus `json:"configured_status"`
 	OperationalState string                      `json:"operational_state,omitempty"`
 	SizeGiB          int                         `json:"size_gib"`

--- a/upcloud/file_storage_test.go
+++ b/upcloud/file_storage_test.go
@@ -63,6 +63,29 @@ func TestFileStorage_MarshalUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestFileStorage_Encrypted(t *testing.T) {
+	t.Run("EncryptedTrue", func(t *testing.T) {
+		var fs FileStorage
+		assert.NoError(t, json.Unmarshal([]byte(`{"uuid":"fs-1","encrypted":true}`), &fs))
+		assert.True(t, fs.Encrypted)
+	})
+
+	t.Run("EncryptedFalse", func(t *testing.T) {
+		var fs FileStorage
+		assert.NoError(t, json.Unmarshal([]byte(`{"uuid":"fs-2","encrypted":false}`), &fs))
+		assert.False(t, fs.Encrypted)
+	})
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		fs := FileStorage{UUID: "fs-3", Encrypted: true}
+		data, err := json.Marshal(fs)
+		assert.NoError(t, err)
+		var out FileStorage
+		assert.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, fs.Encrypted, out.Encrypted)
+	})
+}
+
 func TestFileStorage_MarshalUnmarshalJSON_Errors(t *testing.T) {
 	invalidJSON := []string{
 		"{invalid}",

--- a/upcloud/request/file_storage.go
+++ b/upcloud/request/file_storage.go
@@ -36,6 +36,7 @@ type CreateFileStorageRequest struct {
 	Zone             string                              `json:"zone"`
 	ConfiguredStatus upcloud.FileStorageConfiguredStatus `json:"configured_status"`
 	SizeGiB          int                                 `json:"size_gib"`
+	Encrypted        bool                                `json:"encrypted,omitempty"`
 	Networks         []upcloud.FileStorageNetwork        `json:"networks,omitempty"`
 	Shares           []FileStorageShare                  `json:"shares,omitempty"`
 	Labels           []upcloud.Label                     `json:"labels,omitempty"`

--- a/upcloud/request/file_storage_test.go
+++ b/upcloud/request/file_storage_test.go
@@ -53,6 +53,31 @@ func TestCreateFileStorageRequest_MarshalJSON(t *testing.T) {
 		assert.JSONEq(t, expected, string(data))
 	})
 
+	t.Run("WithEncryption", func(t *testing.T) {
+		req := CreateFileStorageRequest{
+			Name:             "enc",
+			Zone:             "fi-hel1",
+			ConfiguredStatus: "started",
+			SizeGiB:          250,
+			Encrypted:        true,
+		}
+		data, err := json.Marshal(&req)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"name":"enc","zone":"fi-hel1","configured_status":"started","size_gib":250,"encrypted":true}`, string(data))
+	})
+
+	t.Run("WithoutEncryption", func(t *testing.T) {
+		req := CreateFileStorageRequest{
+			Name:             "plain",
+			Zone:             "fi-hel1",
+			ConfiguredStatus: "started",
+			SizeGiB:          250,
+		}
+		data, err := json.Marshal(&req)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"name":"plain","zone":"fi-hel1","configured_status":"started","size_gib":250}`, string(data))
+	})
+
 	t.Run("Full", func(t *testing.T) {
 		req := CreateFileStorageRequest{
 			Name:             "full",


### PR DESCRIPTION
The UpCloud File Storage API supports AES-256-GCM encryption at rest via a boolean encrypted field on POST /file-storage. Add the field to the FileStorage response struct and CreateFileStorageRequest; encryption is immutable after creation so Modify/Replace requests are left unchanged.

This is a required feature before implementation can start on https://github.com/UpCloudLtd/terraform-provider-upcloud/issues/994