### PR TITLE
feat(server): add field for retrieving one-time password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- server: add `OneTimePassword` field to `upcloud.ServerDetails` for retrieving the system generated one-time password.
+
 ## [8.37.0]
 
 ### Added

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -182,12 +182,13 @@ type ServerDetails struct {
 	// TODO: Convert to boolean
 	Firewall string `json:"firewall"`
 	// Deprecated: Use HostID instead.
-	Host                 int                      `json:"host"`
-	HostID               int64                    `json:"-"`
-	IPAddresses          IPAddressSlice           `json:"ip_addresses"`
-	Labels               LabelSlice               `json:"labels"`
-	Metadata             Boolean                  `json:"metadata"`
-	GeneratedPassword    string                   `json:"password"`
+	Host        int            `json:"host"`
+	HostID      int64          `json:"-"`
+	IPAddresses IPAddressSlice `json:"ip_addresses"`
+	Labels      LabelSlice     `json:"labels"`
+	Metadata    Boolean        `json:"metadata"`
+	// The system generated one-time password. Only available in create response when the create_password login option was set to true.
+	OneTimePassword      string                   `json:"password"`
 	NICModel             string                   `json:"nic_model"`
 	Networking           ServerNetworking         `json:"networking"`
 	ServerGroup          string                   `json:"server_group"`

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -187,6 +187,7 @@ type ServerDetails struct {
 	IPAddresses          IPAddressSlice           `json:"ip_addresses"`
 	Labels               LabelSlice               `json:"labels"`
 	Metadata             Boolean                  `json:"metadata"`
+	GeneratedPassword    string                   `json:"password"`
 	NICModel             string                   `json:"nic_model"`
 	Networking           ServerNetworking         `json:"networking"`
 	ServerGroup          string                   `json:"server_group"`


### PR DESCRIPTION
This pull request adds a member to ServerDetails, so that the library user can know the generated password when deploying Windows Servers.