### PR TITLE
fix(kubernetes): remove omitempty tag from modify node group request

### DIFF
--- a/upcloud/request/kubernetes.go
+++ b/upcloud/request/kubernetes.go
@@ -204,7 +204,7 @@ func (r *CreateKubernetesNodeGroupRequest) RequestURL() string {
 }
 
 type ModifyKubernetesNodeGroup struct {
-	Count int `json:"count,omitempty"`
+	Count int `json:"count"`
 }
 
 type ModifyKubernetesNodeGroupRequest struct {

--- a/upcloud/request/kubernetes_test.go
+++ b/upcloud/request/kubernetes_test.go
@@ -443,6 +443,11 @@ func TestModifyKubernetesNodeGroupRequest(t *testing.T) {
 		"count": 4
 	}
 	`
+	const expectedZeroCountJSON string = `
+	{
+		"count": 0
+	}
+	`
 	r := ModifyKubernetesNodeGroupRequest{
 		ClusterUUID: "id",
 		Name:        "nid",
@@ -456,6 +461,11 @@ func TestModifyKubernetesNodeGroupRequest(t *testing.T) {
 		return
 	}
 	assert.JSONEq(t, expectedJSON, string(gotJS))
+
+	r.NodeGroup.Count = 0
+	gotJS, err = json.Marshal(&r)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedZeroCountJSON, string(gotJS))
 }
 
 func TestDeleteKubernetesNodeGroupNodeRequest(t *testing.T) {


### PR DESCRIPTION
This fixes unexpected results when leaving node group count undefined in client side. Count is required field and defaults to zero.