### PR TITLE
fix(service): retry operation before starting ticker

### DIFF
--- a/upcloud/service/retry.go
+++ b/upcloud/service/retry.go
@@ -50,11 +50,22 @@ func shouldRetryOnError(err error, retryOnErrorCount int) bool {
 func retry[T any](ctx context.Context, operation func(int, context.Context) (*T, error), config *retryConfig) (*T, error) {
 	config = fillDefaults(config)
 
+	value, err := operation(0, ctx)
+	if err != nil && !shouldRetryOnError(err, 0) {
+		return value, err
+	}
+	if !config.inverse && value != nil {
+		return value, nil
+	}
+	if config.inverse && value == nil {
+		return nil, nil
+	}
+
 	ticker := time.NewTicker(config.interval)
 	defer ticker.Stop()
 
-	retryOnErrorCount := 0
-	for i := 0; ; i++ {
+	retryOnErrorCount := 1
+	for i := 1; ; i++ {
 		select {
 		case <-ticker.C:
 			value, err := operation(i, ctx)

--- a/upcloud/service/retry_test.go
+++ b/upcloud/service/retry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRetry_noInverse(t *testing.T) {
@@ -78,8 +79,9 @@ func TestRetry_noInterval(t *testing.T) {
 				return &i, nil
 			}, test.config)
 
-			assert.Error(t, err)
-			assert.Nil(t, value)
+			assert.NoError(t, err)
+			require.NotNil(t, value)
+			assert.Equal(t, 0, *value)
 		})
 	}
 }
@@ -130,4 +132,57 @@ func TestRetry_retry500(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetry_deadline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Before interval", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*2)
+		defer cancel()
+
+		wantValue := 0
+		gotValue, err := retry(ctx, func(i int, ctx context.Context) (*int, error) {
+			return &i, ctx.Err()
+		}, &retryConfig{interval: time.Second * 10})
+
+		require.NoError(t, err)
+		require.NotNil(t, gotValue)
+		require.Equal(t, wantValue, *gotValue)
+	})
+
+	t.Run("After interval", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*2)
+		defer cancel()
+
+		c := 0
+		gotValue, err := retry(ctx, func(i int, ctx context.Context) (*int, error) {
+			c++
+			return nil, nil
+		}, &retryConfig{interval: time.Second})
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Nil(t, gotValue)
+		require.Greater(t, c, 1)
+	})
+
+	t.Run("Reached", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), -time.Second)
+		defer cancel()
+
+		wantValue := 0
+		gotValue, err := retry(ctx, func(i int, ctx context.Context) (*int, error) {
+			return &i, ctx.Err()
+		}, &retryConfig{interval: time.Second * 10})
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.NotNil(t, gotValue)
+		require.Equal(t, wantValue, *gotValue)
+	})
 }


### PR DESCRIPTION
Call `operation` immediately when entering `retry` function and start ticker only if more retries are needed.