### PR TITLE
fix(service): set problem status if not defined

### DIFF
--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -165,6 +165,9 @@ func parseJSONServiceError(err error) error {
 			if parseErr := json.Unmarshal(clientError.ResponseBody, prob); parseErr != nil {
 				return fmt.Errorf("received malformed client error (%w): %w", parseErr, err)
 			}
+			if prob.Status == 0 {
+				prob.Status = clientError.ErrorCode
+			}
 			return prob
 		default:
 			ucError := &legacyError{}

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -35,6 +35,22 @@ func TestParseJSONServiceErrorMinimal(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestParseJSONServiceErrorWithProblemMinimal(t *testing.T) {
+	want := &upcloud.Problem{
+		Status: http.StatusBadRequest,
+	}
+
+	got := parseJSONServiceError(&client.Error{
+		ErrorCode: http.StatusBadRequest,
+		Type:      client.ErrorTypeProblem,
+		ResponseBody: []byte(`
+			{
+			}
+		`),
+	})
+	assert.Equal(t, want, got)
+}
+
 func TestParseJSONServiceErrorWithProblem(t *testing.T) {
 	want := &upcloud.Problem{
 		Type:          "typexx",


### PR DESCRIPTION
If status is not set in problem document use HTTP status code received by the client.